### PR TITLE
fix: mobile navbar auto-hide + clean search button + fix FAB click bug

### DIFF
--- a/assets/css/extended/article-bottom-sheet.css
+++ b/assets/css/extended/article-bottom-sheet.css
@@ -6,7 +6,7 @@
 .article-fab {
   display: none;
   position: fixed;
-  bottom: 1.5rem;
+  bottom: 6.5rem;
   right: 1.25rem;
   width: 48px;
   height: 48px;
@@ -48,11 +48,13 @@
   background: rgba(0, 0, 0, 0.4);
   z-index: 210;
   opacity: 0;
+  pointer-events: none;
   transition: opacity 240ms ease;
 }
 
 .abs-overlay--visible {
   opacity: 1;
+  pointer-events: auto;
 }
 
 @media (max-width: 1023px) {
@@ -63,7 +65,8 @@
 
 /* ── Bottom Sheet ───────────────────────────────────────────── */
 .article-bottom-sheet {
-  display: none;
+  display: flex;
+  flex-direction: column;
   position: fixed;
   bottom: 0;
   left: 0;
@@ -76,8 +79,6 @@
   transform: translateY(100%);
   transition: transform 240ms cubic-bezier(0.4, 0, 0.2, 1);
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
 }
 
 .article-bottom-sheet.abs--open {

--- a/assets/css/extended/nav-elegant.css
+++ b/assets/css/extended/nav-elegant.css
@@ -12,6 +12,13 @@
     backdrop-filter: saturate(180%) blur(16px);
     -webkit-backdrop-filter: saturate(180%) blur(16px);
     border-bottom: 1px solid rgba(30, 35, 30, 0.06);
+    transition: transform 0.25s ease;
+    will-change: transform;
+}
+
+/* Auto-hide on scroll-down */
+.header-wrapper.nav-scroll-hidden {
+    transform: translateY(-100%);
 }
 
 body.dark .header-wrapper {
@@ -258,6 +265,29 @@ body.dark .lang-switch a:hover {
     .nav {
         position: relative;
         line-height: 52px;
+    }
+
+    /* Search button: icon-only on mobile, no label or keyboard shortcut */
+    .nav-search-trigger__label,
+    .nav-search-trigger__keys {
+        display: none;
+    }
+
+    .nav-search-trigger {
+        width: 34px;
+        height: 34px;
+        padding: 0;
+        border: none;
+        background: transparent;
+        justify-content: center;
+    }
+
+    .nav-search-trigger:hover {
+        background: rgba(30, 35, 30, 0.05);
+    }
+
+    body.dark .nav-search-trigger:hover {
+        background: rgba(226, 227, 225, 0.06);
     }
 
     .hamburger-menu {

--- a/assets/js/article-bottom-sheet.js
+++ b/assets/js/article-bottom-sheet.js
@@ -2,8 +2,8 @@
 (function () {
   'use strict';
 
-  var FAB_HIDE_SCROLL = 200;   // px from top — hide fab
-  var FAB_HIDE_BOTTOM = 300;   // px from bottom — hide fab near footer
+  var FAB_HIDE_SCROLL = 80;    // px from top — hide fab
+  var FAB_HIDE_BOTTOM = 80;    // px from bottom — hide fab near footer
   var SWIPE_CLOSE = 80;        // px downward swipe to close
 
   var fab, sheet, overlay, tabs, panels;
@@ -42,15 +42,19 @@
   }
 
   function openSheet() {
+    fab.classList.add('article-fab--hidden');
     sheet.classList.add('abs--open');
     overlay.classList.add('abs-overlay--visible');
+    fab.setAttribute('aria-expanded', 'true');
     document.body.style.overflow = 'hidden';
   }
 
   function closeSheet() {
     sheet.classList.remove('abs--open');
     overlay.classList.remove('abs-overlay--visible');
+    fab.setAttribute('aria-expanded', 'false');
     document.body.style.overflow = '';
+    setTimeout(onScroll, 260);
   }
 
   function onScroll() {

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -173,9 +173,12 @@
 {{/* FAB */}}
 <button id="article-fab" class="article-fab" aria-label="{{ i18n "tools.toc" | default "Contents" | safeHTML }}" aria-expanded="false" aria-controls="article-bottom-sheet">
   <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-    <line x1="3" y1="6" x2="21" y2="6"/>
-    <line x1="3" y1="12" x2="21" y2="12"/>
-    <line x1="3" y1="18" x2="21" y2="18"/>
+    <line x1="8" y1="6" x2="21" y2="6"/>
+    <line x1="8" y1="12" x2="21" y2="12"/>
+    <line x1="8" y1="18" x2="21" y2="18"/>
+    <line x1="3" y1="6" x2="3.01" y2="6"/>
+    <line x1="3" y1="12" x2="3.01" y2="12"/>
+    <line x1="3" y1="18" x2="3.01" y2="18"/>
   </svg>
 </button>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -229,4 +229,36 @@ document.addEventListener('click', function(event) {
         hamburger.setAttribute('aria-expanded', 'false');
     }
 });
+
+// Auto-hide navbar on scroll down, reveal on scroll up (Medium-style)
+(function () {
+    var headerWrapper = document.querySelector('.header-wrapper');
+    if (!headerWrapper) return;
+    var lastScrollY = 0;
+    var ticking = false;
+    var THRESHOLD = 80;
+
+    function update() {
+        var currentY = window.scrollY || window.pageYOffset;
+        var menu = document.getElementById('menu');
+        var menuOpen = menu && menu.classList.contains('mobile-open');
+
+        if (!menuOpen) {
+            if (currentY > THRESHOLD && currentY > lastScrollY) {
+                headerWrapper.classList.add('nav-scroll-hidden');
+            } else {
+                headerWrapper.classList.remove('nav-scroll-hidden');
+            }
+        }
+        lastScrollY = currentY;
+        ticking = false;
+    }
+
+    window.addEventListener('scroll', function () {
+        if (!ticking) {
+            requestAnimationFrame(update);
+            ticking = true;
+        }
+    }, { passive: true });
+})();
 </script>


### PR DESCRIPTION
## Summary

- **Auto-hide navbar (Medium-style)**: Header slides up when scrolling down, reappears on scroll-up. Uses 80px threshold, skips hiding when hamburger menu is open.
- **Clean mobile search button**: Hides `⌘K` shortcut and text label on mobile — renders as icon-only for a clean, touch-friendly target (was showing confusing keyboard shortcut that means nothing on mobile).
- **Fix FAB completely unclickable bug**: The `.abs-overlay` had `display:block` + `z-index:210` on mobile with NO `pointer-events:none`, so the invisible overlay silently swallowed all taps above the FAB (z-index 200). Fixed by adding `pointer-events:none` when not visible, `pointer-events:auto` when active.
- **FAB hides on sheet open / restores on close**: FAB now properly hides itself when the bottom sheet opens and restores via `onScroll()` after close.
- **Fix FAB / back-to-top overlap**: Raised FAB from `bottom:1.5rem` to `bottom:6.5rem` so it sits clearly above the back-to-top button (which is at `bottom:60px`).
- **Distinct FAB icon**: Changed from plain three-line hamburger (identical to nav hamburger) to a bulleted-list / TOC icon — users can now distinguish the two buttons.
- **CSS dead-code fix**: `.article-bottom-sheet` had `display:none` immediately overridden by `display:flex` — removed the dead declaration.
- **Tighten FAB show/hide thresholds**: `FAB_HIDE_SCROLL` 200→80px, `FAB_HIDE_BOTTOM` 300→80px so the FAB appears sooner and stays visible longer.

## Test plan

- [ ] Mobile: scroll down on any article — navbar slides up after 80px
- [ ] Mobile: scroll back up — navbar immediately reappears
- [ ] Mobile: open hamburger menu while scrolled — navbar should NOT hide while menu is open
- [ ] Mobile: search button shows only the magnifying-glass icon (no ⌘K, no "Search" text)
- [ ] Mobile: tap FAB (bulleted-list icon, bottom-right) — bottom sheet slides up with TOC/AI/Share tabs
- [ ] Mobile: tap overlay or swipe down on sheet — sheet closes, FAB reappears
- [ ] Mobile: verify FAB and back-to-top button no longer overlap
- [ ] Desktop: navbar auto-hide also works on scroll-down/up

https://claude.ai/code/session_01WyLbHEttPMNR8yv5rTWR2C