### PR TITLE
hide mobile UI elements: progress bar and floating buttons

### DIFF
--- a/assets/css/extended/article-bottom-sheet.css
+++ b/assets/css/extended/article-bottom-sheet.css
@@ -34,11 +34,7 @@
   transform: translateY(8px);
 }
 
-@media (max-width: 1023px) {
-  .article-fab {
-    display: flex;
-  }
-}
+/* FAB hidden on all screen sizes — disabled per design */
 
 /* ── Overlay ────────────────────────────────────────────────── */
 .abs-overlay {

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -2711,6 +2711,16 @@ html {
     box-shadow: 0 0 10px rgba(20, 184, 166, 0.6);
 }
 
+@media (max-width: 1023px) {
+    .reading-progress-bar {
+        display: none;
+    }
+
+    .top-link {
+        display: none !important;
+    }
+}
+
 /* Heading anchor styles */
 .post-content h2:hover .anchor,
 .post-content h3:hover .anchor,


### PR DESCRIPTION
## Summary

- Hide reading progress bar (bottom of page) on mobile (≤1023px)
- Hide back-to-top button (`.top-link`) on mobile (≤1023px)
- Hide article FAB / TOC menu button (`.article-fab`) on all screen sizes — was previously shown only on mobile, now fully removed from display

## Changes

- `assets/css/extended/custom.css`: added `@media (max-width: 1023px)` block to hide `.reading-progress-bar` and `.top-link`
- `assets/css/extended/article-bottom-sheet.css`: removed the `@media (max-width: 1023px)` override that set `.article-fab { display: flex }`, keeping the default `display: none`

## Test plan

- [ ] Open site on a mobile viewport (≤1023px width) and confirm progress bar is not visible
- [ ] Scroll down on an article page — confirm back-to-top button does not appear
- [ ] Confirm the TOC/menu FAB button does not appear on mobile
- [ ] Open on desktop (≥1024px) — confirm progress bar and back-to-top button still work normally

https://claude.ai/code/session_01R8AQJYyUNyzycC5H2dwBmW