### PR TITLE
feat: conversation sharing + AI companion chip fix

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -5509,3 +5509,38 @@ html {
         overflow-wrap: break-word;
     }
 }
+
+/* ── Search palette: share conversation button ── */
+.search-palette__share-btn {
+  flex-shrink: 0;
+  width: 34px;
+  height: 34px;
+  border: 1px solid rgba(140, 110, 75, 0.35);
+  border-radius: 4px;
+  background: rgba(120, 90, 55, 0.06);
+  color: #7a5c40;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+  padding: 0;
+}
+
+.search-palette__share-btn:hover {
+  background: rgba(120, 90, 55, 0.14);
+  border-color: rgba(120, 90, 55, 0.55);
+  color: #5a3a20;
+}
+
+.dark .search-palette__share-btn {
+  border-color: rgba(160, 130, 90, 0.3);
+  background: rgba(80, 60, 35, 0.25);
+  color: #c8a870;
+}
+
+.dark .search-palette__share-btn:hover {
+  background: rgba(100, 75, 45, 0.45);
+  border-color: rgba(160, 130, 90, 0.55);
+  color: #e8c888;
+}

--- a/assets/css/extended/editorial-tools.css
+++ b/assets/css/extended/editorial-tools.css
@@ -347,6 +347,14 @@ body.dark .editorial-tools-panel .rc-ai-chip:hover {
   border-color: rgba(226, 227, 225, 0.2);
 }
 
+.editorial-tools-panel .rc-ai-chip--used,
+.editorial-tools-panel .rc-ai-chip:disabled {
+  opacity: 0.38;
+  cursor: default;
+  pointer-events: none;
+  background: transparent;
+}
+
 /* Messages — prose-like, airy */
 .editorial-tools-panel .rc-ai-messages {
   font-family: var(--font-body);
@@ -478,6 +486,39 @@ html:lang(en) .editorial-tools-panel .rc-ai-send {
 .editorial-tools-panel .rc-ai-send svg {
   width: 13px;
   height: 13px;
+}
+
+.editorial-tools-panel .rc-ai-share-btn {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid rgba(30, 35, 30, 0.12);
+  background: transparent;
+  color: var(--color-ink-muted, #5e5e63);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+  padding: 0;
+}
+
+.editorial-tools-panel .rc-ai-share-btn:hover {
+  background: rgba(30, 35, 30, 0.06);
+  border-color: rgba(30, 35, 30, 0.2);
+  color: var(--color-ink, #1a1c1b);
+}
+
+body.dark .editorial-tools-panel .rc-ai-share-btn {
+  border-color: rgba(226, 227, 225, 0.14);
+  color: rgba(226, 227, 225, 0.5);
+}
+
+body.dark .editorial-tools-panel .rc-ai-share-btn:hover {
+  background: rgba(226, 227, 225, 0.08);
+  border-color: rgba(226, 227, 225, 0.24);
+  color: var(--color-paper, #e2e3e1);
 }
 
 .editorial-tools-panel .rc-ai-loading {

--- a/assets/js/search-palette.js
+++ b/assets/js/search-palette.js
@@ -81,15 +81,22 @@
 
   // Add follow-up input field
   function renderFollowUpInput(lastQuery) {
+    const isZh = (document.documentElement.lang || '').toLowerCase().indexOf('zh') === 0;
     return `
       <div class="search-palette__followup">
         <input
           class="search-palette__followup-input"
           type="text"
-          placeholder="继续追问... (按 Enter 发送)"
+          placeholder="${isZh ? '继续追问… (Enter 发送)' : 'Ask a follow-up… (Enter to send)'}"
           data-followup-query="${lastQuery}"
         />
-        <button class="search-palette__followup-send">发送</button>
+        <button class="search-palette__followup-send">${isZh ? '发送' : 'Send'}</button>
+        <button class="search-palette__share-btn" title="${isZh ? '分享对话' : 'Share conversation'}" aria-label="${isZh ? '分享对话' : 'Share conversation'}">
+          <svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>
+            <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
+          </svg>
+        </button>
       </div>
     `;
   }
@@ -292,6 +299,7 @@
   function attachFollowUpListeners() {
     const followUpInput = aiContent.querySelector('.search-palette__followup-input');
     const followUpBtn = aiContent.querySelector('.search-palette__followup-send');
+    const shareBtn = aiContent.querySelector('.search-palette__share-btn');
 
     if (!followUpInput || !followUpBtn) return;
 
@@ -313,6 +321,17 @@
         }
       }
     });
+
+    // Share conversation
+    if (shareBtn && typeof ShareConversation !== 'undefined') {
+      shareBtn.addEventListener('click', () => {
+        ShareConversation.show(conversationHistory, {
+          lang:  document.documentElement.lang || 'en',
+          title: document.title,
+          url:   window.location.href,
+        });
+      });
+    }
 
     // Focus the input
     setTimeout(() => followUpInput.focus(), 10);

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -2,6 +2,7 @@
 {{- /* <script src="{{ "/js/blog-ai.js" | relURL }}" defer></script> */ -}}
 <script src="{{ "/js/blog-ai-inline.js" | relURL }}" defer></script>
 <script src="{{ "/js/newsletter.js" | relURL }}" defer></script>
+<script src="{{ "/js/share-conversation.js" | relURL }}" defer></script>
 {{- if .IsPage }}
 <script src="{{ "/js/reading-companion.js" | relURL }}" defer></script>
 <script src="{{ "/js/toc-highlight.js" | relURL }}" defer></script>

--- a/static/js/reading-companion.js
+++ b/static/js/reading-companion.js
@@ -149,18 +149,41 @@
     var busy     = false;
     var lastQuestion = '';
 
+    // Share button — injected into input area, shown after first AI reply
+    var shareBtn = document.createElement('button');
+    shareBtn.className = 'rc-ai-share-btn';
+    shareBtn.setAttribute('aria-label', language === 'zh' ? '分享对话' : 'Share conversation');
+    shareBtn.setAttribute('hidden', '');
+    shareBtn.innerHTML =
+      '<svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+        '<circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>' +
+        '<line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>' +
+      '</svg>';
+    var inputArea = panel.querySelector('.rc-ai-input-area');
+    if (inputArea) inputArea.appendChild(shareBtn);
+
+    shareBtn.addEventListener('click', function () {
+      if (typeof ShareConversation === 'undefined') return;
+      ShareConversation.show(history, {
+        lang:  language,
+        title: document.title,
+        url:   window.location.href,
+      });
+    });
+
     // Auto-resize textarea
     textarea.addEventListener('input', function () {
       this.style.height = 'auto';
       this.style.height = Math.min(this.scrollHeight, 96) + 'px';
     });
 
-    // Quick chip → send
+    // Quick chip → send (clicked chip disabled, others stay clickable)
     chips.forEach(function (chip) {
       chip.addEventListener('click', function () {
-        if (busy) return;
+        if (busy || chip.disabled) return;
+        chip.disabled = true;
+        chip.classList.add('rc-ai-chip--used');
         textarea.value = chip.dataset.prompt;
-        quickRow.style.display = 'none';
         send();
       });
     });
@@ -312,6 +335,7 @@
         history.push({ role: 'user', content: q });
         history.push({ role: 'assistant', content: answer });
         if (history.length > 20) history = history.slice(-20);
+        shareBtn.removeAttribute('hidden');
 
       } catch (err) {
         request.cancel();

--- a/static/js/share-conversation.js
+++ b/static/js/share-conversation.js
@@ -1,0 +1,386 @@
+/* share-conversation.js — Canvas card generator + share modal
+   Used by reading-companion and search-palette to share AI conversations. */
+(function (global) {
+  'use strict';
+
+  // ── Inject styles once ──────────────────────────────────────────────────────
+  (function injectStyles() {
+    if (document.getElementById('conv-share-styles')) return;
+    var s = document.createElement('style');
+    s.id = 'conv-share-styles';
+    s.textContent = [
+      '.conv-share-overlay{',
+        'position:fixed;inset:0;',
+        'background:rgba(0,0,0,0.52);',
+        'z-index:10000;',
+        'display:flex;align-items:flex-end;justify-content:center;',
+        'opacity:0;transition:opacity 200ms ease;',
+        'backdrop-filter:blur(3px);-webkit-backdrop-filter:blur(3px);',
+      '}',
+      '.conv-share-overlay--visible{opacity:1;}',
+      '.conv-share-overlay--visible .conv-share-sheet{transform:translateY(0);}',
+      '.conv-share-sheet{',
+        'background:var(--color-paper,#f9f9f7);',
+        'border-radius:18px 18px 0 0;',
+        'padding:20px 20px 28px;',
+        'width:100%;max-width:540px;',
+        'max-height:90vh;overflow-y:auto;',
+        'transform:translateY(24px);',
+        'transition:transform 220ms cubic-bezier(.22,1,.36,1);',
+        'box-shadow:0 -4px 40px rgba(0,0,0,0.18);',
+        'box-sizing:border-box;',
+      '}',
+      'body.dark .conv-share-sheet{background:#252825;}',
+      '.conv-share-handle{',
+        'width:36px;height:4px;border-radius:2px;',
+        'background:rgba(30,35,30,0.15);',
+        'margin:0 auto 18px;',
+      '}',
+      'body.dark .conv-share-handle{background:rgba(226,227,225,0.18);}',
+      '.conv-share-header{',
+        'display:flex;align-items:center;justify-content:space-between;',
+        'margin-bottom:16px;',
+      '}',
+      '.conv-share-title{',
+        'font-family:var(--font-body,system-ui,sans-serif);',
+        'font-size:.9rem;font-weight:600;letter-spacing:.01em;',
+        'color:var(--color-ink,#1a1c1b);',
+      '}',
+      'body.dark .conv-share-title{color:var(--color-paper,#e2e3e1);}',
+      '.conv-share-close{',
+        'width:28px;height:28px;border-radius:50%;border:none;',
+        'background:rgba(30,35,30,0.06);',
+        'color:var(--color-ink-muted,#5e5e63);',
+        'cursor:pointer;display:flex;align-items:center;justify-content:center;',
+        'padding:0;',
+      '}',
+      'body.dark .conv-share-close{background:rgba(226,227,225,0.1);color:rgba(226,227,225,.6);}',
+      '.conv-share-preview{',
+        'border-radius:12px;overflow:hidden;',
+        'margin-bottom:18px;',
+        'background:rgba(30,35,30,0.04);',
+        'min-height:72px;display:flex;align-items:center;justify-content:center;',
+      '}',
+      'body.dark .conv-share-preview{background:rgba(226,227,225,0.04);}',
+      '.conv-share-preview canvas{width:100%;height:auto;display:block;border-radius:10px;}',
+      '.conv-share-actions{display:flex;gap:10px;}',
+      '.conv-share-btn{',
+        'flex:1;display:flex;flex-direction:column;align-items:center;gap:6px;',
+        'padding:12px 8px;',
+        'border:1px solid rgba(30,35,30,0.1);border-radius:11px;',
+        'background:transparent;cursor:pointer;',
+        'font-size:.7rem;font-weight:500;',
+        'font-family:var(--font-body,system-ui,sans-serif);',
+        'color:var(--color-ink,#1a1c1b);',
+        'transition:background 140ms ease,border-color 140ms ease;',
+        'line-height:1.2;',
+      '}',
+      '.conv-share-btn:hover{background:rgba(30,35,30,0.04);border-color:rgba(30,35,30,0.18);}',
+      'body.dark .conv-share-btn{border-color:rgba(226,227,225,0.12);color:var(--color-paper,#e2e3e1);}',
+      'body.dark .conv-share-btn:hover{background:rgba(226,227,225,0.06);border-color:rgba(226,227,225,0.22);}',
+      '.conv-share-btn svg{flex-shrink:0;opacity:.8;}',
+      '.conv-share-btn--done svg{stroke:#22c55e;}',
+      '.conv-share-btn--done span{color:#22c55e;}',
+    ].join('');
+    document.head.appendChild(s);
+  })();
+
+  // ── Canvas card generator ───────────────────────────────────────────────────
+  function generateCard(messages, options) {
+    options = options || {};
+    var title   = options.title   || document.title || '';
+    var url     = options.url     || window.location.href;
+    var siteName = (window.location.hostname || 'AI').replace(/^www\./, '');
+    var dark    = document.body.classList.contains('dark');
+
+    var W = 1080, H = 680;
+    var canvas = document.createElement('canvas');
+    canvas.width  = W;
+    canvas.height = H;
+    var ctx = canvas.getContext('2d');
+
+    // Background gradient
+    var bg = ctx.createLinearGradient(0, 0, W, H);
+    if (dark) {
+      bg.addColorStop(0, '#1e211e');
+      bg.addColorStop(1, '#272b27');
+    } else {
+      bg.addColorStop(0, '#f4f5f2');
+      bg.addColorStop(1, '#eaeae4');
+    }
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, W, H);
+
+    // Top accent bar
+    var accent = dark ? '#4d6a4d' : '#862122';
+    ctx.fillStyle = accent;
+    ctx.fillRect(0, 0, W, 5);
+
+    var ink    = dark ? '#dde0dc' : '#1a1c1b';
+    var muted  = dark ? 'rgba(210,215,210,0.48)' : 'rgba(30,35,30,0.42)';
+    var subtle = dark ? 'rgba(210,215,210,0.12)' : 'rgba(30,35,30,0.08)';
+    var PAD = 68;
+
+    // Header row
+    ctx.font = 'bold 18px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+    ctx.fillStyle = accent;
+    ctx.fillText('AI Conversation', PAD, 58);
+
+    ctx.font = '15px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+    ctx.fillStyle = muted;
+    ctx.fillText(siteName, PAD, 82);
+
+    // Divider
+    ctx.fillStyle = subtle;
+    ctx.fillRect(PAD, 100, W - PAD * 2, 1);
+
+    // Find last Q&A pair
+    var userMsg = null, aiMsg = null;
+    for (var i = messages.length - 1; i >= 0; i--) {
+      if (!aiMsg   && messages[i].role === 'assistant') aiMsg   = messages[i];
+      if (!userMsg && messages[i].role === 'user')      userMsg = messages[i];
+      if (userMsg && aiMsg) break;
+    }
+
+    var y = 136;
+
+    // Question block
+    if (userMsg) {
+      var qRaw = userMsg.content.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+      var qText = qRaw.length > 140 ? qRaw.slice(0, 137) + '…' : qRaw;
+
+      ctx.font = '500 13px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+      ctx.fillStyle = muted;
+      ctx.fillText('Q', PAD, y);
+
+      ctx.font = '600 22px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+      ctx.fillStyle = ink;
+      var qLines = wrapText(ctx, qText, W - PAD * 2 - 36, 22);
+      qLines.slice(0, 3).forEach(function (line) {
+        ctx.fillText(line, PAD + 28, y);
+        y += 34;
+      });
+      y += 18;
+    }
+
+    // Divider between Q and A
+    ctx.fillStyle = subtle;
+    ctx.fillRect(PAD, y - 4, W - PAD * 2, 1);
+    y += 20;
+
+    // Answer block
+    if (aiMsg) {
+      var aRaw = aiMsg.content.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+      var aText = aRaw.length > 340 ? aRaw.slice(0, 337) + '…' : aRaw;
+
+      ctx.font = '500 13px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+      ctx.fillStyle = muted;
+      ctx.fillText('A', PAD, y);
+
+      ctx.font = '18px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+      ctx.fillStyle = dark ? 'rgba(210,215,210,0.82)' : 'rgba(30,35,30,0.72)';
+      var aLines = wrapText(ctx, aText, W - PAD * 2 - 36, 18);
+      var maxLines = Math.min(aLines.length, 7);
+      aLines.slice(0, maxLines).forEach(function (line, idx) {
+        ctx.fillText(line, PAD + 28, y + idx * 30);
+      });
+      if (aLines.length > maxLines) {
+        ctx.fillStyle = muted;
+        ctx.fillText('…', PAD + 28, y + maxLines * 30);
+      }
+    }
+
+    // Footer
+    ctx.fillStyle = subtle;
+    ctx.fillRect(PAD, H - 72, W - PAD * 2, 1);
+
+    ctx.font = '13px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+    ctx.fillStyle = muted;
+    var shortUrl = url.length > 64 ? url.slice(0, 61) + '…' : url;
+    ctx.fillText(shortUrl, PAD, H - 44);
+
+    if (title) {
+      ctx.font = '500 13px -apple-system,"Inter","Helvetica Neue","PingFang SC",sans-serif';
+      ctx.fillStyle = ink;
+      ctx.textAlign = 'right';
+      var shortTitle = title.length > 48 ? title.slice(0, 45) + '…' : title;
+      ctx.fillText(shortTitle, W - PAD, H - 44);
+      ctx.textAlign = 'left';
+    }
+
+    return canvas;
+  }
+
+  function wrapText(ctx, text, maxWidth) {
+    // Word-aware wrapping that also handles CJK (no spaces between chars)
+    var lines = [], line = '';
+    // Try character-level for CJK, word-level otherwise
+    var hasCJK = /[\u4e00-\u9fff\u3040-\u30ff]/.test(text);
+    if (hasCJK) {
+      for (var i = 0; i < text.length; i++) {
+        var test = line + text[i];
+        if (ctx.measureText(test).width > maxWidth && line) {
+          lines.push(line);
+          line = text[i];
+        } else {
+          line = test;
+        }
+      }
+    } else {
+      var words = text.split(' ');
+      for (var w = 0; w < words.length; w++) {
+        var test2 = line ? line + ' ' + words[w] : words[w];
+        if (ctx.measureText(test2).width > maxWidth && line) {
+          lines.push(line);
+          line = words[w];
+        } else {
+          line = test2;
+        }
+      }
+    }
+    if (line) lines.push(line);
+    return lines;
+  }
+
+  function formatAsText(messages, options) {
+    options = options || {};
+    var title = options.title || document.title || '';
+    var url   = options.url   || window.location.href;
+    var out   = [];
+    if (title) { out.push(title); out.push(''); }
+    messages.forEach(function (msg) {
+      var prefix  = msg.role === 'user' ? 'Q: ' : 'A: ';
+      var content = msg.content.replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+      out.push(prefix + content);
+      out.push('');
+    });
+    out.push(url);
+    return out.join('\n');
+  }
+
+  // ── Share modal ─────────────────────────────────────────────────────────────
+  function show(messages, options) {
+    options = options || {};
+    if (!messages || !messages.length) return;
+    var isZh = options.lang === 'zh' ||
+               (document.documentElement.getAttribute('lang') || '').toLowerCase().indexOf('zh') === 0;
+
+    var existing = document.getElementById('conv-share-modal');
+    if (existing) existing.remove();
+
+    var overlay = document.createElement('div');
+    overlay.id = 'conv-share-modal';
+    overlay.className = 'conv-share-overlay';
+
+    var webShareBtn = navigator.share
+      ? '<button class="conv-share-btn" id="csb-web-share" aria-label="Share">' +
+          '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>' +
+          '<span>' + (isZh ? '分享' : 'Share') + '</span></button>'
+      : '';
+
+    overlay.innerHTML =
+      '<div class="conv-share-sheet">' +
+        '<div class="conv-share-handle"></div>' +
+        '<div class="conv-share-header">' +
+          '<span class="conv-share-title">' + (isZh ? '分享对话' : 'Share Conversation') + '</span>' +
+          '<button class="conv-share-close" aria-label="Close">' +
+            '<svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>' +
+          '</button>' +
+        '</div>' +
+        '<div class="conv-share-preview" id="csp-preview"></div>' +
+        '<div class="conv-share-actions">' +
+          '<button class="conv-share-btn" id="csb-copy-text" aria-label="Copy text">' +
+            '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>' +
+            '<span>' + (isZh ? '复制文本' : 'Copy text') + '</span>' +
+          '</button>' +
+          '<button class="conv-share-btn" id="csb-save-img" aria-label="Save image">' +
+            '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>' +
+            '<span>' + (isZh ? '保存图片' : 'Save image') + '</span>' +
+          '</button>' +
+          webShareBtn +
+        '</div>' +
+      '</div>';
+
+    document.body.appendChild(overlay);
+
+    // Generate and insert canvas preview
+    var canvas = generateCard(messages, options);
+    var previewArea = document.getElementById('csp-preview');
+    previewArea.appendChild(canvas);
+
+    function closeModal() {
+      overlay.classList.remove('conv-share-overlay--visible');
+      setTimeout(function () { if (overlay.parentNode) overlay.remove(); }, 220);
+    }
+
+    function btnDone(id, label) {
+      var btn = document.getElementById(id);
+      if (!btn) return;
+      btn.classList.add('conv-share-btn--done');
+      var sp = btn.querySelector('span');
+      var orig = sp.textContent;
+      sp.textContent = label;
+      setTimeout(function () {
+        btn.classList.remove('conv-share-btn--done');
+        sp.textContent = orig;
+      }, 2200);
+    }
+
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) closeModal();
+    });
+    overlay.querySelector('.conv-share-close').addEventListener('click', closeModal);
+
+    document.getElementById('csb-copy-text').addEventListener('click', function () {
+      var text = formatAsText(messages, options);
+      if (navigator.clipboard) {
+        navigator.clipboard.writeText(text).then(function () {
+          btnDone('csb-copy-text', isZh ? '已复制 ✓' : 'Copied ✓');
+        });
+      } else {
+        var ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.cssText = 'position:fixed;opacity:0';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+        btnDone('csb-copy-text', isZh ? '已复制 ✓' : 'Copied ✓');
+      }
+    });
+
+    document.getElementById('csb-save-img').addEventListener('click', function () {
+      var a = document.createElement('a');
+      a.download = 'ai-conversation.png';
+      a.href = canvas.toDataURL('image/png');
+      a.click();
+      btnDone('csb-save-img', isZh ? '已保存 ✓' : 'Saved ✓');
+    });
+
+    var wsBtn = document.getElementById('csb-web-share');
+    if (wsBtn) {
+      wsBtn.addEventListener('click', function () {
+        canvas.toBlob(function (blob) {
+          var file = new File([blob], 'ai-conversation.png', { type: 'image/png' });
+          var shareData = {
+            title: options.title || (isZh ? 'AI 对话' : 'AI Conversation'),
+            text:  formatAsText(messages, options).slice(0, 300),
+            url:   options.url || window.location.href,
+          };
+          if (navigator.canShare && navigator.canShare({ files: [file] })) {
+            shareData.files = [file];
+          }
+          navigator.share(shareData).catch(function () {});
+        });
+      });
+    }
+
+    // Animate in
+    requestAnimationFrame(function () {
+      overlay.classList.add('conv-share-overlay--visible');
+    });
+  }
+
+  global.ShareConversation = { show: show };
+
+}(window));


### PR DESCRIPTION
## Summary

- **AI companion chips fix**: clicking a chip now disables only that chip (grayed out, pointer-events none) while all other chips remain interactive — previously the entire quick-start row was hidden after the first click
- **Share conversation**: new `share-conversation.js` utility adds elegant conversation sharing to both the AI reading companion and the search palette AI dialog
- **Canvas card**: generates a 1080×680 branded image card (dark/light theme aware, CJK text wrapping) with the last Q&A pair, site name, URL, and page title
- **Share modal**: bottom-sheet UI with three options — copy as formatted text, save as PNG image, and native Web Share API (when available on device)
- **Share button placement**: appears in the reading companion input area after the first AI reply; appears in the search palette followup row alongside the send button

## Test plan

- [ ] Open an article with the AI reading companion (≥1280px)
- [ ] Click one quick-start chip → it should gray out; click another chip → it should still work
- [ ] After AI responds, a share icon button appears in the input bar → click it
- [ ] Share modal opens with canvas preview, copy-text, save-image, and (on mobile) Share button
- [ ] Open search (Ctrl/Cmd+K), ask a question → after AI responds the followup row has a share icon → click it
- [ ] Verify dark mode card looks correct (dark background)
- [ ] Verify Chinese page uses 中文 labels in the share modal

https://claude.ai/code/session_01HK6ete6Ng7rh8aFMB9rTUT