### PR TITLE
fix: remove Share tab from right sidebar & hide Chronicle when date unset

### DIFF
--- a/layouts/partials/article/editorial-tools.html
+++ b/layouts/partials/article/editorial-tools.html
@@ -31,15 +31,6 @@
       </svg>
       <span>{{ i18n "tools.ai" | default "AI" | safeHTML }}</span>
     </button>
-    <button class="rc-tab" role="tab"
-            aria-selected="false" aria-controls="rc-panel-share"
-            id="rc-tab-share" data-tab="share">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-        <circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/>
-        <line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/>
-      </svg>
-      <span>{{ i18n "tools.share" | default "Share" | safeHTML }}</span>
-    </button>
   </div>
 
   {{/* ── Panel 1: Table of Contents ── */}}
@@ -110,38 +101,5 @@
     </div>
   </div>
 
-  {{/* ── Panel 3: Share + Annotations placeholder ── */}}
-  <div class="rc-panel" id="rc-panel-share" role="tabpanel" aria-labelledby="rc-tab-share" hidden>
-    <div class="et-share-row">
-      <a class="et-share-btn" href="https://x.com/intent/tweet?url={{ .Permalink | urlquery }}&text={{ .Title | urlquery }}"
-         target="_blank" rel="noopener noreferrer" aria-label="Share on X">
-        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.746l7.73-8.835L1.254 2.25H8.08l4.26 5.632zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
-        </svg>
-      </a>
-      <button class="et-share-btn" aria-label="Share via WeChat"
-              data-title="{{ .Title }}" data-url="{{ .Permalink }}" data-desc="{{ .Description }}"
-              onclick="openWechatQR(this)">
-        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-          <path d="M8.5 3C4.36 3 1 5.9 1 9.5c0 2.04 1.04 3.86 2.67 5.07L3 17l2.7-1.35A8.9 8.9 0 0 0 8.5 16c.17 0 .34 0 .51-.01A5.96 5.96 0 0 1 9 14.5c0-3.31 2.91-6 6.5-6 .17 0 .33.01.5.02C15.27 5.6 12.2 3 8.5 3zm-2 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm4 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm5.5 4C12.91 11.5 11 13.32 11 15.5s1.91 4 5 4c.64 0 1.25-.1 1.82-.28L20 20.5l-.5-2.14A3.97 3.97 0 0 0 21 15.5c0-2.18-1.91-4-5-4zm-1.5 2.5a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5zm3 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5z"/>
-        </svg>
-      </button>
-      <button class="et-share-btn et-share-copy" aria-label="Copy link" data-href="{{ .Permalink }}">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <rect x="9" y="9" width="13" height="13" rx="2" ry="2"/>
-          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/>
-        </svg>
-      </button>
-      <a class="et-share-btn" href="mailto:?subject={{ .Title | urlquery }}&body={{ .Permalink | urlquery }}"
-         aria-label="Share via Email">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-          <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/>
-          <polyline points="22,6 12,13 2,6"/>
-        </svg>
-      </a>
-    </div>
-    <p class="et-empty et-annotations-label">{{ i18n "tools.annotations" | default "Annotations" | safeHTML }}</p>
-    <p class="et-empty et-annotations-placeholder">{{ i18n "tools.annotations_empty" | default "Coming soon" | safeHTML }}</p>
-  </div>
 
 </aside>

--- a/layouts/partials/article/marginalia.html
+++ b/layouts/partials/article/marginalia.html
@@ -28,6 +28,8 @@
   {{- $archivesURL := "/archives/" }}
   {{- if eq $page.Lang "en" }}{{ $archivesURL = "/en/archives/" }}{{ end }}
   {{- if eq $page.Lang "zh" }}{{ $archivesURL = "/zh/archives/" }}{{ end }}
+  {{- $zeroTime := "0001-01-01" }}
+  {{- if ne ($page.Date.Format "2006-01-02") $zeroTime }}
   <div class="marginalia-group">
     <span class="marginalia-label">{{ i18n "marginalia.chronicle" | default "Chronicle" }}</span>
     <a href="{{ $archivesURL | relURL }}" class="marginalia-value marginalia-date marginalia-link">
@@ -38,6 +40,7 @@
       {{- end -}}
     </a>
   </div>
+  {{- end }}
 
   {{/* ── Dimensions (Reading Time + Word Count) ── */}}
   <div class="marginalia-group">


### PR DESCRIPTION
## Summary

- **Remove Share tab** from right sidebar (`editorial-tools.html`): the Share tab button and its panel have been removed. Share functionality already exists in the left marginalia sidebar, so it was redundant in the right panel.
- **Fix Chronicle date showing `January 1, 0001`** (`marginalia.html`): wrap the Chronicle date block with a zero-date guard — pages that have no `date` field in their front matter will no longer display the bogus `0001-01-01` date.

## Test plan

- [ ] Visit any article page — right sidebar should show only **Contents** and **AI Companion** tabs (no Share tab)
- [ ] Visit a page without a `date` field (e.g. `start-here`) — **CHRONICLE** section should be hidden
- [ ] Visit a page with a valid `date` field — **CHRONICLE** still shows the correct date