### PR TITLE
fix: move robots.txt from static/ to layouts/ so all three Sitemap entries deploy

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -1,10 +1,14 @@
 User-agent: *
+{{- if hugo.IsProduction | or (eq site.Params.env "production") }}
 Allow: /
+{{- else }}
+Disallow: /
+{{- end }}
 
 # Sitemaps
-Sitemap: https://nsddd.top/sitemap.xml
-Sitemap: https://nsddd.top/en/sitemap.xml
-Sitemap: https://nsddd.top/zh/sitemap.xml
+Sitemap: {{ "sitemap.xml" | absURL }}
+Sitemap: {{ "en/sitemap.xml" | absURL }}
+Sitemap: {{ "zh/sitemap.xml" | absURL }}
 
 # Disallow admin and private areas
 Disallow: /admin/
@@ -34,13 +38,3 @@ Allow: /
 
 User-agent: LinkedInBot
 Allow: /
-
-# Block AI scrapers (optional - uncomment if needed)
-# User-agent: GPTBot
-# Disallow: /
-#
-# User-agent: ChatGPT-User
-# Disallow: /
-#
-# User-agent: CCBot
-# Disallow: /


### PR DESCRIPTION
## 根因分析

`static/robots.txt` 自定义版本**从未生效**。

Hugo 的处理顺序：
1. 先把 `layouts/robots.txt`（主题模板）渲染到 `public/robots.txt`
2. 再复制 `static/` 目录到 `public/`
3. **生成文件优先**：`enableRobotsTXT: true` 时，Hugo 不复制 `static/robots.txt`（冲突时模板版本获胜）

结果：Netlify 线上始终是 PaperMod 默认的 robots.txt（只有一个 Sitemap 条目，没有 en/ 和 zh/ 语言子站）。

## 修复

将 `static/robots.txt` → `layouts/robots.txt`，覆盖 PaperMod 主题的同名模板。

模板增加了环境感知逻辑：
```
{{- if hugo.IsProduction | or (eq site.Params.env "production") }}
Allow: /   ← 生产环境开放爬取
{{- else }}
Disallow: /  ← 非生产环境屏蔽（防止 staging 被索引）
{{- end }}
```

以及三个 Sitemap 指令：
```
Sitemap: https://nsddd.top/sitemap.xml
Sitemap: https://nsddd.top/en/sitemap.xml
Sitemap: https://nsddd.top/zh/sitemap.xml
```

## 关于其他报告问题的说明

| 报告问题 | 实际状态 |
|---------|---------|
| 404 页面在 sitemap 中 | ✅ 本地构建已无 404，是线上旧缓存显示，PR #178 已修复 |
| en/sitemap.xml "Unsupported format" | ✅ 已是标准 `<urlset>` 格式（含 hreflang），GSC 需 1-3 天重新验证 |
| en 内容 0 个 | ✅ en 内容用根路径（`/growth/...` 非 `/en/growth/...`），正常 |
| zh URL 混入 en sitemap | ✅ 仅存在于 `<xhtml:link hreflang>` 标签（正确），`<loc>` 中无跨语言污染 |

## Test plan

- [ ] 构建后 `public/robots.txt` 包含三个 Sitemap 条目
- [ ] 生产环境：`Allow: /`；非生产：`Disallow: /`
- [ ] 部署后 `curl https://nsddd.top/robots.txt` 看到三个 Sitemap 行

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated robots.txt to conditionally manage crawler access based on environment
  * Modernized sitemap URL generation for multi-language support
  * Streamlined crawler access rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->