### PR TITLE
fix: sitemap XML encoding (&lt; → <?xml) + 404 noindex

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,7 +1,9 @@
 <meta charset="utf-8">
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-{{- if hugo.IsProduction | or (eq site.Params.env "production") | and (ne .Params.robotsNoIndex true) }}
+{{- if or (eq .Kind "404") .Params.robotsNoIndex }}
+<meta name="robots" content="noindex, nofollow">
+{{- else if hugo.IsProduction | or (eq site.Params.env "production") }}
 <meta name="robots" content="index, follow">
 {{- else }}
 <meta name="robots" content="noindex, nofollow">

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+{{- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
@@ -6,15 +6,11 @@
   {{- range .Site.Pages -}}
     {{- $page := . -}}
     {{- $skip := false -}}
-    {{/* Skip private pages */}}
     {{- if .Params.private }}{{ $skip = true }}{{ end -}}
-    {{/* Skip noindex pages */}}
     {{- if .Params.robotsNoIndex }}{{ $skip = true }}{{ end -}}
-    {{/* Skip sitemap-excluded pages */}}
     {{- if eq .Params.sitemap_exclude true }}{{ $skip = true }}{{ end -}}
-    {{/* Skip utility pages (search, archives, categories listing) */}}
     {{- if in $excludedLayouts .Layout }}{{ $skip = true }}{{ end -}}
-    {{/* Only include real content kinds */}}
+    {{- if or (eq .Kind "404") (strings.Contains .RelPermalink "/404") }}{{ $skip = true }}{{ end -}}
     {{- if not (in (slice "page" "home" "section" "taxonomy" "term") .Kind) }}{{ $skip = true }}{{ end -}}
     {{- if not $skip -}}
   <url>
@@ -51,7 +47,6 @@
       <image:loc>{{ .Params.cover.image | absURL }}</image:loc>
     </image:image>
     {{- end }}
-    {{/* hreflang alternate links for translated pages */}}
     {{- if .IsTranslated }}
     {{- range .AllTranslations }}
     <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}"/>


### PR DESCRIPTION
## 根因

两个独立的 bug，但来源都是 Hugo 模板渲染机制。

---

### Bug 1：en/zh sitemap.xml 开头是 `&lt;?xml` 而不是 `<?xml`

**根因**：Hugo 将 `layouts/sitemap.xml` 在 **HTML template context** 中渲染，Go template 的 HTML auto-escaping 把 `<` 转义为 `&lt;`。即使设置了 `minify.disableXML: true` 也无法阻止这一行为，因为这不是 minify 问题，而是渲染上下文问题。

**修复**：把 XML 声明行改为通过 `safeHTML` 输出，绕过 HTML 转义：
```go
{{- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
```

**验证**：
```
# 修复前（hex）
00: 26 6c 74 3b 3f 78 6d 6c  → &lt;?xml

# 修复后（hex）  
00: 3c 3f 78 6d 6c 20       → <?xml
```

---

### Bug 2：`/404` 页面有 `robots: index, follow`

**根因**：`head.html` 的 robots meta 逻辑只检查 `.Params.robotsNoIndex`，而 404 页面的 `.Kind == "404"`，没有 front matter，永远不触发 noindex。

**修复**：在判断链最前面加 `.Kind == "404"` 检查：
```go
{{- if or (eq .Kind "404") .Params.robotsNoIndex }}
<meta name="robots" content="noindex, nofollow">
{{- else if hugo.IsProduction | or (eq site.Params.env "production") }}
<meta name="robots" content="index, follow">
```

同时在 sitemap 模板中过滤 `/404` 路径（含分页 `/404/page/1-9`）：
```go
{{- if or (eq .Kind "404") (strings.Contains .RelPermalink "/404") }}{{ $skip = true }}{{ end -}}
```

---

## 验证结果

| 检查项 | 期望 | 实际 |
|--------|------|------|
| en/sitemap.xml 首字节 | `0x3c` (`<`) | ✅ `3c 3f 78 6d 6c` |
| 404 robots meta | noindex,nofollow | ✅ |
| 首页 robots meta | index,follow | ✅ |
| sitemap 中 /404 URL 数 | 0 | ✅ |
| sitemap 中 search/archives | 0 | ✅ |

## Test plan
- [ ] GSC 重新验证 en/sitemap.xml 和 zh/sitemap.xml 状态变为 Success
- [ ] `curl https://nsddd.top/en/sitemap.xml | head -c 6` 输出 `<?xml`
- [ ] `curl https://nsddd.top/404 | grep robots` 显示 noindex