### PR TITLE
feat: redesign related articles section with card grid layout

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -5552,50 +5552,126 @@ html {
   border-top: 1px solid var(--border);
 }
 
-.related-posts-title {
-  font-size: 1rem;
-  font-weight: 600;
-  margin-bottom: 0.75rem;
-  color: var(--primary);
+.related-posts-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
 }
 
-.related-posts-list {
-  list-style: none;
-  padding: 0;
+.related-posts-header::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.related-posts-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  white-space: nowrap;
   margin: 0;
+}
+
+.related-posts-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+}
+
+@media (max-width: 768px) {
+  .related-posts-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .related-posts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.related-post-card {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  text-decoration: none;
+  color: var(--primary);
+  background: var(--entry);
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
 }
 
-.related-post-item {
+.related-post-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
+  border-color: var(--primary);
+  text-decoration: none;
+  color: var(--primary);
+}
+
+.related-post-card-accent {
+  height: 3px;
+  background: var(--primary);
+  opacity: 0.7;
+  transition: opacity 0.18s ease;
+}
+
+.related-post-card:hover .related-post-card-accent {
+  opacity: 1;
+}
+
+.related-post-card-body {
+  flex: 1;
+  padding: 0.85rem 0.9rem 0.5rem;
+}
+
+.related-post-card-title {
+  font-size: 0.875rem;
+  font-weight: 500;
+  line-height: 1.45;
+  margin: 0 0 0.6rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.related-post-card-tags {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
-.related-post-link {
+.related-post-tag {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.45rem;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  color: var(--secondary);
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}
+
+.related-post-card-footer {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  gap: 1rem;
-  width: 100%;
-  padding: 0.4rem 0;
-  color: var(--primary);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-  transition: border-color 0.15s;
+  align-items: center;
+  padding: 0.5rem 0.9rem 0.75rem;
+  margin-top: auto;
 }
 
-.related-post-link:hover {
-  border-bottom-color: var(--primary);
-}
-
-.related-post-title {
-  flex: 1;
-  font-size: 0.9rem;
-}
-
-.related-post-date {
-  flex-shrink: 0;
-  font-size: 0.8rem;
+.related-post-card-date {
+  font-size: 0.75rem;
   color: var(--secondary);
+}
+
+.related-post-card-read {
+  font-size: 0.72rem;
+  color: var(--secondary);
+  opacity: 0.75;
 }

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -1,18 +1,34 @@
-{{- $related := .Site.RegularPages.Related . | first 4 -}}
+{{- $related := .Site.RegularPages.Related . | first 3 -}}
 {{- with $related -}}
 <div class="related-posts">
-  <h3 class="related-posts-title">相关文章 / Related Posts</h3>
-  <ul class="related-posts-list">
+  <div class="related-posts-header">
+    <h3 class="related-posts-title">相关文章 / Related Posts</h3>
+  </div>
+  <div class="related-posts-grid">
     {{- range . -}}
-    <li class="related-post-item">
-      <a href="{{ .RelPermalink }}" class="related-post-link">
-        <span class="related-post-title">{{ .Title }}</span>
-        {{- if .Date -}}
-        <span class="related-post-date">{{ .Date.Format "2006-01-02" }}</span>
+    {{- $tags := .Params.tags -}}
+    <a href="{{ .RelPermalink }}" class="related-post-card">
+      <div class="related-post-card-accent"></div>
+      <div class="related-post-card-body">
+        <p class="related-post-card-title">{{ .Title }}</p>
+        {{- if $tags -}}
+        <div class="related-post-card-tags">
+          {{- range first 2 $tags -}}
+          <span class="related-post-tag">{{ . }}</span>
+          {{- end -}}
+        </div>
         {{- end -}}
-      </a>
-    </li>
+      </div>
+      <div class="related-post-card-footer">
+        {{- if .Date -}}
+        <span class="related-post-card-date">{{ .Date.Format "2006-01-02" }}</span>
+        {{- end -}}
+        {{- if .ReadingTime -}}
+        <span class="related-post-card-read">{{ .ReadingTime }} min read</span>
+        {{- end -}}
+      </div>
+    </a>
     {{- end -}}
-  </ul>
+  </div>
 </div>
 {{- end -}}


### PR DESCRIPTION
## Summary

Closes #184

Replaces the flat `<ul>` list in the "相关文章 / Related Posts" section with a responsive 3-column card grid that is both visually appealing and more informative.

**Key changes:**

- `layouts/partials/related-posts.html` — new card structure with accent bar, tag pills, and reading time
- `assets/css/extended/custom.css` — full card grid CSS with hover lift animation and responsive breakpoints

## What changed visually

**Before:** plain 4-row list, title + date on one line, no visual separation  
**After:** 3-card grid with:
- 3px colored top accent strip (uses `--primary`)
- Article title with 3-line clamp for uniform card height
- First 2 tags as pill badges
- Date + reading time in the card footer
- Hover: `translateY(-3px)` lift + `box-shadow` + border highlight
- Responsive: `3-col` → `2-col (≤768px)` → `1-col (≤480px)`

## Design notes

- Uses only existing CSS variables (`--primary`, `--secondary`, `--border`, `--entry`) so it works in both light and dark themes automatically
- No JS — pure CSS transitions
- Count reduced from 4 to 3 items (better visual balance for a grid)

## Test plan

- [ ] View any article page and scroll to the bottom
- [ ] Confirm 3 cards render in a row on desktop
- [ ] Resize to tablet (≤768px) — should switch to 2 columns
- [ ] Resize to mobile (≤480px) — should stack to 1 column
- [ ] Hover over a card — lift + border highlight animation
- [ ] Check dark mode — cards should use dark `--entry` background

https://claude.ai/code/session_01WHgg7GXw6VzPHxwrNYwc89