### PR TITLE
fix(styles): override PaperMod --hljs-bg so light-mode code blocks are actually light

### DIFF
--- a/assets/css/extended/article-typography.css
+++ b/assets/css/extended/article-typography.css
@@ -299,19 +299,20 @@ body.dark .post-content hr {
 .post-content .highlight,
 .post-content pre:not(.mermaid) {
   position: relative;
-  margin: 1.75rem 0;
-  border-radius: 10px;
+  margin: 1.75rem 0 !important;
+  border-radius: 10px !important;
   overflow: hidden;
   max-width: 100%;
-  background: var(--code-surface);
-  border: 1px solid var(--code-border);
-  box-shadow: var(--code-shadow);
+  background: var(--code-surface) !important;
+  border: 1px solid var(--code-border) !important;
+  box-shadow: var(--code-shadow) !important;
 }
 
 /* ── 1. Light / English (default) — GitHub Light inspired ── */
 .post-content .highlight,
 .post-content pre:not(.mermaid) {
   --code-surface: #f6f8fa;
+  --hljs-bg: var(--code-surface);
   --code-ink: #24292f;
   --code-border: rgba(31, 35, 40, 0.15);
   --code-shadow: 0 1px 3px rgba(31,35,40,0.04),
@@ -329,6 +330,7 @@ body.dark .post-content hr {
 html:lang(zh) .post-content .highlight,
 html:lang(zh) .post-content pre:not(.mermaid) {
   --code-surface: #faf8f5;
+  --hljs-bg: var(--code-surface);
   --code-ink: #350003;
   --code-border: rgba(53, 0, 3, 0.10);
   --code-shadow: 0 1px 2px rgba(53,0,3,0.03),
@@ -346,6 +348,7 @@ html:lang(zh) .post-content pre:not(.mermaid) {
 body.dark:not(:lang(zh)) .post-content .highlight,
 body.dark:not(:lang(zh)) .post-content pre:not(.mermaid) {
   --code-surface: #0d1117;
+  --hljs-bg: var(--code-surface);
   --code-ink: #e6edf3;
   --code-border: rgba(240,246,252,0.10);
   --code-shadow: 0 1px 2px rgba(0,0,0,0.12),
@@ -363,6 +366,7 @@ body.dark:not(:lang(zh)) .post-content pre:not(.mermaid) {
 body.dark:lang(zh) .post-content .highlight,
 body.dark:lang(zh) .post-content pre:not(.mermaid) {
   --code-surface: #1c1917;
+  --hljs-bg: var(--code-surface);
   --code-ink: #f5f3ee;
   --code-border: rgba(245,243,238,0.08);
   --code-shadow: 0 1px 2px rgba(0,0,0,0.12),


### PR DESCRIPTION
## Root cause

PaperMod's `post-single.css` contains:

```css
.post-content .highlight:not(table) {
  background: var(--hljs-bg) !important;   /* specificity 0-2-1 */
}
```

And in `:root`: `--hljs-bg: rgb(28, 29, 33)` — a near-black dark color.

Because of `!important` + higher specificity (0-2-1 vs our 0-2-0), PaperMod's rule always won, making code blocks dark even in light mode — regardless of our `--code-surface` variable.

## Fix

In each of the 4 per-language variant blocks, add:
```css
--hljs-bg: var(--code-surface);
```

This redirects PaperMod's own `var(--hljs-bg)` reference to resolve to our intended surface color (e.g. `#f6f8fa` for light EN, `#faf8f5` for light ZH).

Also added `!important` to `background`, `margin`, `border-radius`, `border`, and `box-shadow` in the shared layout block to fully beat PaperMod's higher-specificity overrides.

## Result

| Variant | Background |
|---|---|
| Light / EN | `#f6f8fa` (GitHub white) ✓ |
| Light / ZH | `#faf8f5` (warm white) ✓ |
| Dark / EN | `#0d1117` (GitHub dark) ✓ |
| Dark / ZH | `#1c1917` (warm brown) ✓ |

## Test plan

- [ ] Visit a ZH article in light mode → code blocks are clearly light (`#faf8f5`)
- [ ] Visit an EN article in light mode → code blocks are GitHub-white (`#f6f8fa`)
- [ ] Toggle dark mode → code blocks switch to correct dark variant
- [ ] No regressions to prose, blockquotes, or inline code

https://claude.ai/code/session_01SVhGDA9awfvq9JArLYmmHF