### PR TITLE
feat: TOC auto-scroll + related posts redesign

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -5547,131 +5547,174 @@ html {
 
 /* ─── Related Posts ─────────────────────────────────────────── */
 .related-posts {
-  margin-top: 3rem;
-  padding-top: 1.5rem;
+  margin-top: 4rem;
+  padding-top: 2rem;
   border-top: 1px solid var(--border);
 }
 
 .related-posts-header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
 }
 
-.related-posts-header::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--border);
+.related-posts-eyebrow {
+  display: block;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  opacity: 0.6;
+  margin-bottom: 0.3rem;
 }
 
 .related-posts-title {
-  font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--secondary);
-  white-space: nowrap;
+  font-size: 1.15rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--primary);
   margin: 0;
+  line-height: 1.3;
 }
 
+.related-posts-title-en {
+  font-weight: 400;
+  color: var(--secondary);
+  font-size: 0.95em;
+}
+
+/* Grid: 3-col on wide, 1-col stacked list on narrow */
 .related-posts-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+  gap: 1px;
+  background: var(--border);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  overflow: hidden;
 }
 
-@media (max-width: 768px) {
-  .related-posts-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (max-width: 480px) {
+@media (max-width: 720px) {
   .related-posts-grid {
     grid-template-columns: 1fr;
   }
 }
 
-.related-post-card {
+/* ─── Related Post Card (rpc) ────────────────────────────────── */
+.rpc {
+  position: relative;
   display: flex;
   flex-direction: column;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
   text-decoration: none;
   color: var(--primary);
   background: var(--entry);
-  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  padding: 1.25rem 1.1rem 1.1rem;
+  transition: background 0.15s ease;
+  min-height: 120px;
 }
 
-.related-post-card:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.12);
-  border-color: var(--primary);
+.rpc:hover {
+  background: var(--code-bg, rgba(0,0,0,0.03));
   text-decoration: none;
   color: var(--primary);
 }
 
-.related-post-card-accent {
-  height: 3px;
-  background: var(--primary);
-  opacity: 0.7;
-  transition: opacity 0.18s ease;
+body.dark .rpc:hover {
+  background: rgba(255,255,255,0.04);
 }
 
-.related-post-card:hover .related-post-card-accent {
-  opacity: 1;
-}
-
-.related-post-card-body {
-  flex: 1;
-  padding: 0.85rem 0.9rem 0.5rem;
-}
-
-.related-post-card-title {
-  font-size: 0.875rem;
-  font-weight: 500;
-  line-height: 1.45;
-  margin: 0 0 0.6rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
+/* Optional cover image strip */
+.rpc__cover {
+  margin: -1.25rem -1.1rem 0.9rem;
+  height: 120px;
   overflow: hidden;
 }
 
-.related-post-card-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.35rem;
+.rpc__cover img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.3s ease;
 }
 
-.related-post-tag {
-  font-size: 0.7rem;
-  padding: 0.15rem 0.45rem;
-  border-radius: 20px;
-  border: 1px solid var(--border);
+.rpc:hover .rpc__cover img {
+  transform: scale(1.04);
+}
+
+/* Tags row */
+.rpc__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  margin-bottom: 0.55rem;
+}
+
+.rpc__tag {
+  font-size: 0.68rem;
+  font-weight: 500;
+  padding: 0.1rem 0.5rem;
+  border-radius: 99px;
+  background: var(--border);
   color: var(--secondary);
   text-transform: lowercase;
   letter-spacing: 0.02em;
 }
 
-.related-post-card-footer {
+/* Title */
+.rpc__title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1.5;
+  margin: 0 0 auto;
+  padding-bottom: 0.75rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  color: var(--primary);
+}
+
+/* Body wrapper */
+.rpc__body {
+  flex: 1;
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+}
+
+/* Meta row */
+.rpc__meta {
+  display: flex;
   align-items: center;
-  padding: 0.5rem 0.9rem 0.75rem;
-  margin-top: auto;
+  gap: 0.4rem;
+  margin-top: 0.6rem;
 }
 
-.related-post-card-date {
-  font-size: 0.75rem;
-  color: var(--secondary);
-}
-
-.related-post-card-read {
+.rpc__date,
+.rpc__read {
   font-size: 0.72rem;
   color: var(--secondary);
-  opacity: 0.75;
+  opacity: 0.7;
+}
+
+.rpc__sep {
+  color: var(--secondary);
+  opacity: 0.4;
+  font-size: 0.72rem;
+}
+
+/* Arrow indicator */
+.rpc__arrow {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
+  font-size: 0.9rem;
+  color: var(--secondary);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.rpc:hover .rpc__arrow {
+  opacity: 0.5;
+  transform: translateX(0);
 }

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -1,34 +1,43 @@
 {{- $related := .Site.RegularPages.Related . | first 3 -}}
 {{- with $related -}}
-<div class="related-posts">
+<section class="related-posts">
   <div class="related-posts-header">
-    <h3 class="related-posts-title">相关文章 / Related Posts</h3>
+    <span class="related-posts-eyebrow">继续阅读</span>
+    <h3 class="related-posts-title">相关文章 <span class="related-posts-title-en">/ Related Posts</span></h3>
   </div>
   <div class="related-posts-grid">
     {{- range . -}}
     {{- $tags := .Params.tags -}}
-    <a href="{{ .RelPermalink }}" class="related-post-card">
-      <div class="related-post-card-accent"></div>
-      <div class="related-post-card-body">
-        <p class="related-post-card-title">{{ .Title }}</p>
+    {{- $cover := .Params.cover -}}
+    {{- $hasCover := and $cover $cover.image -}}
+    <a href="{{ .RelPermalink }}" class="rpc{{- if $hasCover }} rpc--has-cover{{- end }}">
+      {{- if $hasCover -}}
+      <div class="rpc__cover" aria-hidden="true">
+        <img src="{{ $cover.image }}" alt="" loading="lazy" decoding="async">
+      </div>
+      {{- end -}}
+      <div class="rpc__body">
         {{- if $tags -}}
-        <div class="related-post-card-tags">
+        <div class="rpc__tags">
           {{- range first 2 $tags -}}
-          <span class="related-post-tag">{{ . }}</span>
+          <span class="rpc__tag">{{ . }}</span>
           {{- end -}}
         </div>
         {{- end -}}
+        <p class="rpc__title">{{ .Title }}</p>
+        <div class="rpc__meta">
+          {{- if .Date -}}
+          <span class="rpc__date">{{ .Date.Format "2006-01-02" }}</span>
+          {{- end -}}
+          {{- if .ReadingTime -}}
+          <span class="rpc__sep" aria-hidden="true">·</span>
+          <span class="rpc__read">{{ .ReadingTime }} min</span>
+          {{- end -}}
+        </div>
       </div>
-      <div class="related-post-card-footer">
-        {{- if .Date -}}
-        <span class="related-post-card-date">{{ .Date.Format "2006-01-02" }}</span>
-        {{- end -}}
-        {{- if .ReadingTime -}}
-        <span class="related-post-card-read">{{ .ReadingTime }} min read</span>
-        {{- end -}}
-      </div>
+      <span class="rpc__arrow" aria-hidden="true">→</span>
     </a>
     {{- end -}}
   </div>
-</div>
+</section>
 {{- end -}}

--- a/static/js/reading-companion.js
+++ b/static/js/reading-companion.js
@@ -74,6 +74,20 @@
     var OFFSET = 140;
     var rafPending = false;
 
+    // Scroll the active TOC item into view within the sticky panel container
+    function scrollTocItemIntoView(link) {
+      // The scrollable container is .editorial-tools-panel (overflow-y: auto)
+      var container = link.closest('.editorial-tools-panel') || link.closest('.toc-side__nav');
+      if (!container) return;
+      var containerRect = container.getBoundingClientRect();
+      var linkRect = link.getBoundingClientRect();
+      var padding = 40;
+      if (linkRect.top < containerRect.top + padding || linkRect.bottom > containerRect.bottom - padding) {
+        var targetScrollTop = container.scrollTop + (linkRect.top - containerRect.top) - (containerRect.height / 2) + (linkRect.height / 2);
+        container.scrollTo({ top: targetScrollTop, behavior: 'smooth' });
+      }
+    }
+
     function updateActive() {
       rafPending = false;
       var scrollY = window.scrollY || window.pageYOffset;
@@ -87,7 +101,10 @@
       }
       if (activeSection === currentActive) return;
       if (currentActive) currentActive.link.classList.remove('toc-active');
-      if (activeSection) activeSection.link.classList.add('toc-active');
+      if (activeSection) {
+        activeSection.link.classList.add('toc-active');
+        scrollTocItemIntoView(activeSection.link);
+      }
       currentActive = activeSection;
     }
 


### PR DESCRIPTION
## Summary

- **TOC auto-scroll**: when scrolling through a long article, the active heading in the right-side TOC panel now automatically scrolls into view (smooth, centered) — no more manual scrolling inside the TOC to find where you are
- **Related posts redesign**: replaced the plain card grid with a unified border-grid layout (Linear/Vercel Blog style), cleaner typography hierarchy, capsule tags, hover arrow indicator, and optional cover image strip

## Changes

- `static/js/reading-companion.js` — added `scrollTocItemIntoView()` that triggers on every active-section change, targeting `.editorial-tools-panel` as the scroll container
- `layouts/partials/related-posts.html` — new markup using `.rpc` BEM classes with eyebrow label, cover image support, and arrow indicator
- `assets/css/extended/custom.css` — replaced old `.related-post-card` styles with `.rpc` design system; unified 1px-gap grid border, responsive single-column on mobile

## Test plan

- [ ] Open a long article (e.g. `/zh/growth/posts/2025-11-thought-notes/`) and scroll — verify TOC active item stays visible in the right panel
- [ ] Check related posts section at bottom looks correct on desktop (3-col grid) and mobile (1-col)
- [ ] Hover a related post card — arrow `→` should appear and slide in
- [ ] Dark mode check — cards and borders should render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Redesigned "Related Posts" section with improved spacing, updated header layout, and new card styling including hover effects.
  * Related post cards now feature optional cover images with enhanced visual presentation.

* **Features**
  * Table of Contents active items now automatically scroll into view while reading for better navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->