### PR TITLE
fix(seo): resolve Google Search Console sitemap out-of-scope errors

### DIFF
--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -7,8 +7,6 @@ Disallow: /
 
 # Sitemaps
 Sitemap: {{ "sitemap.xml" | absURL }}
-Sitemap: {{ "en/sitemap.xml" | absURL }}
-Sitemap: {{ "zh/sitemap.xml" | absURL }}
 
 # Disallow admin and private areas
 Disallow: /admin/

--- a/layouts/sitemapindex.xml
+++ b/layouts/sitemapindex.xml
@@ -1,0 +1,75 @@
+{{- "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
+{{- /*
+  Custom sitemapindex override: outputs a single unified urlset for all languages.
+
+  Background: defaultContentLanguageInSubdir is false, so EN URLs live at root
+  (e.g. /growth/posts/...) while Hugo places en/sitemap.xml under /en/.
+  Google rejects /en/sitemap.xml because the URLs inside are out of scope for /en/.
+
+  Fix: replace the sitemapindex with one combined urlset covering all languages,
+  submitted as a single /sitemap.xml. The per-language sitemaps at /en/ and /zh/
+  still exist on disk but are no longer advertised in robots.txt.
+*/ -}}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:xhtml="http://www.w3.org/1999/xhtml"
+        xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  {{- $excludedLayouts := slice "search" "archives" "categories" }}
+  {{- $seen := dict }}
+  {{- range site.Sites }}
+    {{- range .Pages }}
+      {{- $page := . }}
+      {{- $skip := false }}
+      {{- if .Params.private }}{{ $skip = true }}{{ end }}
+      {{- if .Params.robotsNoIndex }}{{ $skip = true }}{{ end }}
+      {{- if eq .Params.sitemap_exclude true }}{{ $skip = true }}{{ end }}
+      {{- if in $excludedLayouts .Layout }}{{ $skip = true }}{{ end }}
+      {{- if or (eq .Kind "404") (strings.Contains .RelPermalink "/404") }}{{ $skip = true }}{{ end }}
+      {{- if not (in (slice "page" "home" "section" "taxonomy" "term") .Kind) }}{{ $skip = true }}{{ end }}
+      {{- if not $skip }}
+        {{- if not (index $seen .Permalink) }}
+          {{- $seen = merge $seen (dict .Permalink true) }}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    {{- if not .Lastmod.IsZero }}
+    <lastmod>{{ .Lastmod.Format "2006-01-02T15:04:05+08:00" }}</lastmod>
+    {{- else if not .Date.IsZero }}
+    <lastmod>{{ .Date.Format "2006-01-02T15:04:05+08:00" }}</lastmod>
+    {{- end }}
+    {{- if .Params.changefreq }}
+    <changefreq>{{ .Params.changefreq }}</changefreq>
+    {{- else if eq .Kind "home" }}
+    <changefreq>daily</changefreq>
+    {{- else if eq .Kind "section" }}
+    <changefreq>weekly</changefreq>
+    {{- else }}
+    <changefreq>monthly</changefreq>
+    {{- end }}
+    {{- if .Params.sitemapPriority }}
+    <priority>{{ .Params.sitemapPriority }}</priority>
+    {{- else if eq .Kind "home" }}
+    <priority>1.0</priority>
+    {{- else if eq .Kind "section" }}
+    <priority>0.8</priority>
+    {{- else if eq .Kind "taxonomy" }}
+    <priority>0.6</priority>
+    {{- else if eq .Kind "term" }}
+    <priority>0.5</priority>
+    {{- else }}
+    <priority>0.7</priority>
+    {{- end }}
+    {{- if .Params.cover.image }}
+    <image:image>
+      <image:loc>{{ .Params.cover.image | absURL }}</image:loc>
+    </image:image>
+    {{- end }}
+    {{- if .IsTranslated }}
+    {{- range .AllTranslations }}
+    <xhtml:link rel="alternate" hreflang="{{ .Language.Lang }}" href="{{ .Permalink }}"/>
+    {{- end }}
+    {{- end }}
+  </url>
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+</urlset>


### PR DESCRIPTION
## 问题分析

Google Search Console 中多个 sitemap 报 **"1 error, 0 pages"**，根本原因是 sitemap URL out-of-scope 错误。

### 根本原因

`config.yml` 设置了 `defaultContentLanguageInSubdir: false`，EN（默认语言）内容 URL 直接在根目录（无 `/en/` 前缀）。Hugo 多语言模式仍将 EN sitemap 生成在 `/en/sitemap.xml`，导致路径与 URL 范围不匹配：

| 文件位置 | Google 期望 URL 范围 | 实际 URL 范围 | 结果 |
|---|---|---|---|
| `/en/sitemap.xml` | `https://nsddd.top/en/...` | `https://nsddd.top/growth/...` | ❌ out of scope |
| `/zh/sitemap.xml` | `https://nsddd.top/zh/...` | `https://nsddd.top/zh/...` | ✅ 正确 |

## 修复内容

### `layouts/sitemapindex.xml`（新建）
覆盖 Hugo 内置的 sitemapindex 行为，输出单一统一的 urlset，遍历所有语言（EN+ZH）所有页面：
- **518 个 URL**（225 EN + 293 ZH）
- 完整的 `hreflang xhtml:link` 标注，双语互相关联
- 使用 `site.Sites` 遍历所有语言，`$seen` 去重防止重复 URL

### `layouts/robots.txt`（修改）
移除 `en/sitemap.xml` 和 `zh/sitemap.xml` 的声明，只保留 `/sitemap.xml`。

## 验证

构建后 `public/sitemap.xml` 从 sitemapindex 格式变为单一 urlset，包含所有语言页面：

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" ...>
  <url>
    <loc>https://nsddd.top/growth/posts/...</loc>
    <xhtml:link rel="alternate" hreflang="en" href="..."/>
    <xhtml:link rel="alternate" hreflang="zh" href="..."/>
  </url>
  ...
</urlset>
```

## 后续操作（需在 Search Console 手动处理）

部署后需在 Google Search Console 删除以下失效 sitemap 记录：
- `https://nsddd.top/en/sitemap.xml`
- `https://nsddd.top/zh/sitemap.xml`
- `https://nsddd.top/zh/posts/`
- `https://nsddd.top/zh/categories/ai-open-source/`