### PR TITLE
fix(nav): correct en archives/categories URLs (404 fix)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -219,9 +219,9 @@ languages:
           - name: AI Projects
             url: /projects/
           - name: Archives
-            url: /en/archives/
+            url: /archives/
           - name: Categories
-            url: /en/categories/
+            url: /categories/
       editPost:
           URL: "https://github.com/cubxxw/blog/edit/main/content/en"
           Text: "Suggest Changes" # edit text


### PR DESCRIPTION
## Problem

`/en/archives/` returned 404 because `defaultContentLanguageInSubdir: false` in config.yml — the default language (English) is served at the root path, not under `/en/`.

## Fix

- `/en/archives/` → `/archives/`
- `/en/categories/` → `/categories/`

Both `content/en/archives.md` and `content/en/categories.md` exist and will be served correctly at the root paths.

## Test plan
- [ ] Visit `/archives/` — should show archives page
- [ ] Visit `/categories/` — should show categories page
- [ ] Homepage "Archives" button navigates correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated navigation link URLs for Archives and Categories in site configuration to use simplified path structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->