### PR TITLE
fix(related-posts): resolve cover.image relative paths to working URLs

### DIFF
--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -9,11 +9,29 @@
     {{- range . -}}
     {{- $tags := .Params.tags -}}
     {{- $cover := .Params.cover -}}
-    {{- $hasCover := and $cover $cover.image -}}
+    {{- $coverURL := "" -}}
+    {{- with $cover -}}
+      {{- with .image -}}
+        {{- if or (hasPrefix . "http://") (hasPrefix . "https://") (hasPrefix . "/") -}}
+          {{- $coverURL = . -}}
+        {{- else -}}
+          {{- with $.Resources.GetMatch . -}}
+            {{- $coverURL = .RelPermalink -}}
+          {{- else -}}
+            {{- with resources.GetMatch . -}}
+              {{- $coverURL = .RelPermalink -}}
+            {{- else -}}
+              {{- $coverURL = relURL . -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $hasCover := ne $coverURL "" -}}
     <a href="{{ .RelPermalink }}" class="rpc{{- if $hasCover }} rpc--has-cover{{- end }}">
       {{- if $hasCover -}}
       <div class="rpc__cover" aria-hidden="true">
-        <img src="{{ $cover.image }}" alt="" loading="lazy" decoding="async">
+        <img src="{{ $coverURL }}" alt="" loading="lazy" decoding="async">
       </div>
       {{- end -}}
       <div class="rpc__body">


### PR DESCRIPTION
## Summary
- Related-posts cards rendered broken images when a related post's `cover.image` was a non-leading-slash path (e.g. `images/blog/foo.webp`). The browser resolved the `src` against the current article's URL — not against the related post's bundle or the site root — so the image 404'd in the card while still rendering fine on the post's own page.
- Resolve `cover.image` inside `layouts/partials/related-posts.html`: absolute URLs and site-relative paths pass through unchanged; relative paths try the related page's bundle resources, then global assets, and finally fall back to a site-relative URL via `relURL` so authors who omit the leading slash still get a valid `src`.

## Test plan
- [x] Local `netlify dev` — verified the affected posts (`Context 不是 Prompt`, `Agent Engineering 全景地图`) now render their covers in related-posts cards.
- [x] `curl` checks: resolved URLs (`/images/blog/context-engineering-desk.webp`, `/images/blog/agent-engineering-harness.webp`, `/images/blog/relay-agent-architecture.webp`) all return HTTP 200.
- [x] Visual check on `/zh/ai-technology/posts/agent-engineering-the-98-percent-harness/` — three related cards have valid `<img src>` values; no broken thumbnails.
- [ ] Smoke-check a Page Bundle post whose cover lives inside its own bundle (relative resource path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how related posts display cover images, with better handling for absolute URLs, root-relative paths, and site resources.
  * Related post cards now more reliably show or hide the cover image styling based on whether a valid image is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->