### PR TITLE
feat(feeds + polish): full XML subscription stack, motion & a11y polish

### DIFF
--- a/assets/css/extended/article-tldr.css
+++ b/assets/css/extended/article-tldr.css
@@ -280,6 +280,24 @@
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.01)),
     color-mix(in srgb, var(--color-accent) 8%, transparent);
+  /* The base box-shadow carries a bright `0 1px 0 rgba(255,255,255,0.6) inset`
+     top-edge bevel tuned for the light paper. On the dark card that white
+     hairline reads as a glare line across the top inner edge. Drop the inset
+     to a faint lift and keep only a soft dark ambient shadow. Gated on .dark —
+     light mode keeps its original glossy bevel untouched. */
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.04) inset,
+    0 24px 60px -34px color-mix(in srgb, var(--color-accent) 30%, transparent);
+}
+
+/* The closing "world-line terminus" node fills with the accent and hardcodes
+   `color:#fff`. In dark/EN the accent flips to light sky-blue (#7dd3fc), so
+   white digits on it drop to ~1.67:1 (illegible). Use the page paper tone as
+   the on-accent ink (the idiom used elsewhere in this codebase): dark ink on
+   the light-blue / red dark accent reads at 11:1 (EN) / 6.3:1 (ZH). Gated on
+   .dark — light mode (dark accent) keeps white. */
+.dark .tldr-item:last-child .tldr-node {
+  color: var(--color-paper);
 }
 .dark .tldr-node,
 .dark .tldr-item:last-child .tldr-node {

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -1849,6 +1849,105 @@ details summary,
   flex-shrink: 0;
 }
 
+/* ── Channel list (subscribe by section, JSON Feed, OPML) ── */
+.rss-channels {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px dashed var(--border, rgba(148, 163, 184, 0.25));
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.rss-channels__label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--secondary, #94a3b8);
+  margin: 0 0 6px;
+}
+
+.rss-channels__row {
+  display: grid;
+  grid-template-columns: 8px 1fr auto;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  transition: background 0.12s ease;
+}
+.rss-channels__row:hover {
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.rss-channels__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--ch-color, #94a3b8);
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.04);
+}
+
+.rss-channels__name {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--primary);
+  letter-spacing: 0.005em;
+}
+.rss-channels__name--link {
+  color: var(--primary);
+  text-decoration: none;
+  transition: color 0.12s ease;
+}
+.rss-channels__name--link:hover {
+  color: var(--ch-color, #f97316);
+}
+
+.rss-channels__formats {
+  display: inline-flex;
+  gap: 4px;
+}
+
+.rss-channels__chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px 9px;
+  border-radius: 6px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-decoration: none;
+  color: var(--secondary, #64748b);
+  background: rgba(148, 163, 184, 0.1);
+  border: 1px solid transparent;
+  transition: color 0.12s ease, background 0.12s ease, border-color 0.12s ease;
+  min-width: 38px;
+  line-height: 1.4;
+}
+.rss-channels__chip:hover {
+  background: rgba(148, 163, 184, 0.18);
+  border-color: currentColor;
+}
+.rss-channels__chip--rss:hover  { color: #f97316; }
+.rss-channels__chip--json:hover { color: #3b82f6; }
+.rss-channels__chip--opml:hover { color: #a855f7; }
+
+.dark .rss-channels__chip {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--secondary);
+}
+.dark .rss-channels__chip:hover {
+  background: rgba(148, 163, 184, 0.22);
+}
+
+@media (max-width: 480px) {
+  .rss-channels__row  { padding: 5px 6px; gap: 8px; }
+  .rss-channels__name { font-size: 0.8rem; }
+  .rss-channels__chip { padding: 2px 7px; min-width: 34px; font-size: 0.6rem; }
+}
+
 /* ── Newsletter Form ── */
 .newsletter-form {
   display: grid;

--- a/assets/css/extended/homepage-daypage.css
+++ b/assets/css/extended/homepage-daypage.css
@@ -1638,6 +1638,90 @@ body.dark .hp-project-featured.hp-ink   { background: linear-gradient(135deg, #2
 }
 .hp-subscribe-rss:hover { color: var(--accent); border-color: var(--accent); }
 
+/* ── Channel pills: subscribe by section ── */
+.hp-subscribe-channels {
+  grid-column: 1 / -1;
+  margin-top: 24px;
+  padding-top: 20px;
+  border-top: 1px dashed var(--accent-border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hp-subscribe-channels-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.8px;
+  text-transform: uppercase;
+  color: var(--fg-subtle);
+}
+
+.hp-subscribe-channels-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hp-channel-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 10px 5px 9px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--surface-white);
+  text-decoration: none;
+  font-family: var(--font-body);
+  font-size: 12px;
+  color: var(--fg-muted);
+  transition: border-color 160ms, color 160ms, transform 160ms;
+}
+.hp-channel-pill:hover {
+  border-color: var(--ch-color, var(--accent));
+  color: var(--fg-primary);
+  transform: translateY(-1px);
+}
+
+.hp-channel-pill-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--ch-color, var(--accent));
+  flex-shrink: 0;
+}
+
+.hp-channel-pill-name {
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.hp-channel-pill-fmt {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  color: var(--fg-subtle);
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: rgba(0, 0, 0, 0.04);
+  margin-left: 2px;
+}
+.hp-channel-pill:hover .hp-channel-pill-fmt {
+  color: var(--ch-color, var(--accent));
+  background: rgba(0, 0, 0, 0.06);
+}
+
+body.dark .hp-channel-pill-fmt { background: rgba(255, 255, 255, 0.06); }
+body.dark .hp-channel-pill:hover .hp-channel-pill-fmt { background: rgba(255, 255, 255, 0.1); }
+
+@media (max-width: 720px) {
+  .hp-subscribe-channels { margin-top: 20px; padding-top: 16px; }
+  .hp-channel-pill { font-size: 11.5px; padding: 4px 9px 4px 8px; }
+  .hp-channel-pill-fmt { font-size: 8.5px; }
+}
+
 /* ============================================================
    FOOTER
    ============================================================ */

--- a/assets/css/extended/interaction-polish.css
+++ b/assets/css/extended/interaction-polish.css
@@ -55,6 +55,40 @@ html.motion-reveal .post-content :is(h1, h2, h3, h4, h5, h6):target::before {
   pointer-events: none;
 }
 
+/* ---------- JS-triggered landing flash (in-page TOC clicks) ----------
+   The :target pulse above only fires on real fragment navigation: an
+   initial deep-link load, or the browser changing the hash. The sidebar
+   table of contents (toc-highlight.js) intercepts its own clicks for
+   smooth scrolling and updates the URL with history.replaceState(), which
+   does NOT re-match :target — so following a heading from the contents
+   list scrolled the reader to it with no "you landed here" cue at all.
+   (The right-side reading-companion TOC uses native anchors, so :target
+   still fires there; this only backfills the sidebar / any JS jump.)
+   toc-highlight.js adds .anchor-target-flash to the destination on click;
+   we replay the exact same wash + accent-bar so the two paths feel
+   identical. Same .motion-reveal gate and reduced-motion neutralisation
+   as the :target rules, so no-JS / motion-averse visitors are unaffected. */
+html.motion-reveal .post-content .anchor-target-flash {
+  animation: target-wash 2s cubic-bezier(0.22, 0.61, 0.36, 1) 1;
+  border-radius: 6px;
+}
+html.motion-reveal .post-content :is(h1, h2, h3, h4, h5, h6).anchor-target-flash {
+  position: relative;
+}
+html.motion-reveal .post-content :is(h1, h2, h3, h4, h5, h6).anchor-target-flash::before {
+  content: "";
+  position: absolute;
+  left: -0.6rem;
+  top: 0.1em;
+  bottom: 0.1em;
+  width: 3px;
+  border-radius: 3px;
+  background: var(--color-accent, var(--primary));
+  transform-origin: top center;
+  animation: target-bar 2s cubic-bezier(0.22, 0.61, 0.36, 1) 1;
+  pointer-events: none;
+}
+
 /* ---------- TOC links: tap feedback (mobile) ----------
    micro-interactions.css already adds a hover slide for pointer users.
    Add a quick press response so taps on the contents list feel as
@@ -103,6 +137,14 @@ html.motion-reveal .reading-progress-bar {
     background-color: transparent !important;
   }
   html.motion-reveal .post-content :is(h1, h2, h3, h4, h5, h6):target::before {
+    animation: none !important;
+    display: none !important;
+  }
+  html.motion-reveal .post-content .anchor-target-flash {
+    animation: none !important;
+    background-color: transparent !important;
+  }
+  html.motion-reveal .post-content :is(h1, h2, h3, h4, h5, h6).anchor-target-flash::before {
     animation: none !important;
     display: none !important;
   }

--- a/assets/css/extended/micro-interactions.css
+++ b/assets/css/extended/micro-interactions.css
@@ -210,6 +210,14 @@ button:focus-visible,
     var(--shadow-md, 0 4px 16px rgba(15, 23, 42, 0.18)),
     0 0 0 6px color-mix(in srgb, var(--color-accent, var(--primary)) 18%, transparent);
 }
+/* The puck hardcodes `color:#fff` on an accent fill. In dark/EN the accent is
+   light sky-blue (#7dd3fc), so the white chevron drops to ~1.67:1 — worst when
+   armed (solid fill). Use the page paper tone as the on-accent ink in dark
+   (dark glyph on the light dark-accent: 11:1 EN / 6.3:1 ZH). `.dark` outranks
+   the base selector. Gated on .dark — light mode keeps the white chevron. */
+.dark .swipe-hint {
+  color: var(--color-paper);
+}
 
 /* ---------- Animated section underline (links in prose) ---------- */
 /* A small left-to-right underline grow on hover for inline links. */

--- a/assets/css/extended/micro-interactions.css
+++ b/assets/css/extended/micro-interactions.css
@@ -18,7 +18,12 @@ html.motion-reveal .ai-tech-card,
 html.motion-reveal .growth-card,
 html.motion-reveal .ai-tech-list-item,
 html.motion-reveal .growth-list-item,
-html.motion-reveal .reveal-item {
+html.motion-reveal .reveal-item,
+/* Related-post cards at the foot of an article join the same cascade so
+   the page keeps unfolding right to the "continue reading" zone instead
+   of the grid popping in fully-formed. Staggered per row by the shared
+   .related-posts-grid parent (see micro-interactions.js). */
+html.motion-reveal .rpc {
   opacity: 0;
   /* translateY for the rise + a hair of scale so the card "settles"
      into place rather than just sliding — a slightly more premium
@@ -39,7 +44,8 @@ html.motion-reveal .ai-tech-card.is-revealed,
 html.motion-reveal .growth-card.is-revealed,
 html.motion-reveal .ai-tech-list-item.is-revealed,
 html.motion-reveal .growth-list-item.is-revealed,
-html.motion-reveal .reveal-item.is-revealed {
+html.motion-reveal .reveal-item.is-revealed,
+html.motion-reveal .rpc.is-revealed {
   opacity: 1;
   transform: none;
 }
@@ -374,6 +380,7 @@ button:focus-visible,
   .ai-tech-list-item,
   .growth-list-item,
   .reveal-item,
+  .rpc,
   .post-content .reveal-block,
   .post-content img {
     opacity: 1 !important;

--- a/assets/css/extended/zz-dark-reading.css
+++ b/assets/css/extended/zz-dark-reading.css
@@ -1017,3 +1017,32 @@ body.dark .profile_panel__icon--ai,
 [data-theme="dark"] .profile_panel__icon--ai {
   color: #818cf8;
 }
+
+/* ── 30. Inline <code> chip — bring into the contained-chip family (dark) ──
+   Inline code is one of the most-frequent inline elements in this blog's
+   technical prose. The base dark rule (article-typography.css, "Inline Code —
+   pill style": `body.dark .post-content :not(pre) > code`) paints a FLAT
+   `rgba(255,255,255,0.10)` fill with `border: none`. At 0.10 white over the
+   near-black paper that pill is the BRIGHTEST small surface in otherwise-calm
+   dark prose — every other lifted surface in the dark design sits far quieter
+   and is given a hairline rule to contain it: <kbd> (§11) uses a 0.06 fill +
+   a 0.22 token border, <details> (§8) a 0.025 fill + a token border, table
+   headers (§2) a 0.05 band. So a paragraph peppered with inline code reads as
+   a row of glaring patches that pull the eye off the sentence — the one
+   element meant to sit quietly INSIDE the prose shouts above it.
+
+   Bring the inline-code chip into that same contained-chip family: drop the
+   fill to a calmer 0.06 lift (matching <kbd>) and add a 1px token rule so the
+   chip is defined by its EDGE rather than a bright fill — the standard dark-UI
+   idiom, and the move this file already makes for every other inline surface.
+   The code text itself stays `var(--color-ink)` (≈14:1 on the paper — set by
+   the base rule, untouched here), so legibility and discoverability are
+   preserved; only the surrounding glare is calmed. ZH resolves automatically
+   via --color-rule. The selector matches the base rule's specificity exactly
+   (0,2,1) and loads LAST in the extended bundle, so it wins in dark; light
+   mode keeps its `rgba(0,0,0,0.06)` pill, provably unchanged. */
+body.dark .post-content :not(pre) > code,
+[data-theme="dark"] .post-content :not(pre) > code {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--color-rule, rgba(226, 227, 225, 0.14));
+}

--- a/assets/css/extended/zz-dark-reading.css
+++ b/assets/css/extended/zz-dark-reading.css
@@ -959,3 +959,61 @@ body.dark select:focus-visible,
   outline-offset: 3px;
   border-radius: 3px;
 }
+
+/* ── 27. Newsletter form status messages (dark) ──────────────────
+   The RSS / newsletter sign-up form (layouts/partials/rss-subscribe.html)
+   shows a one-line status after submit, coloured by state in custom.css:
+   success #15803d, warning #b45309, error #b91c1c. Those three rules are
+   NOT theme-gated and the form carries NO dark styling at all, so in dark
+   mode the message lands on the near-black page surface (#121413 EN /
+   #1c1917 ZH) at: success 3.69:1 / 3.49:1, warning 3.68:1 / 3.48:1,
+   error 2.86:1 / 2.70:1 — every state UNDER the WCAG-AA 4.5:1 text floor,
+   the error badly so. The feedback the reader most needs to read after
+   acting (did my sign-up work?) rendered as a dim, hard-to-parse smudge.
+   Repaint each state in the lighter -400 tint of the same hue family the
+   rest of the dark palette already uses, so the messages read clearly on
+   the dark surface while keeping the green/amber/red semantic coding:
+   success #4ade80 → 10.62:1 / 10.04:1, warning #fbbf24 → 11.08:1 / 10.48:1,
+   error #f87171 → 6.69:1 / 6.32:1 — all comfortably AA. Each selector is
+   body.dark-scoped (specificity 0,3,0 vs the source 0,2,0, and loaded last
+   in the extended bundle) so it wins in dark and is never selected in light
+   — light mode keeps its darker tints, provably unchanged. */
+body.dark .newsletter-form__status[data-state="success"],
+[data-theme="dark"] .newsletter-form__status[data-state="success"] { color: #4ade80; }
+body.dark .newsletter-form__status[data-state="warning"],
+[data-theme="dark"] .newsletter-form__status[data-state="warning"]  { color: #fbbf24; }
+body.dark .newsletter-form__status[data-state="error"],
+[data-theme="dark"] .newsletter-form__status[data-state="error"]    { color: #f87171; }
+
+/* ── 28. AI-projects sidebar widget heading (dark) ───────────────
+   The "AI Projects" sidebar widget (layouts/partials/sidebar-ai-projects.html)
+   titles itself with `.widget-ai-projects h3 { color: #6b46c1 }` (custom.css),
+   un-gated, on a faint violet/blue gradient that over the dark paper is still
+   essentially the dark surface. In dark mode that deep violet resolves to just
+   2.88:1 (EN) / 2.72:1 (ZH) — well under the AA 4.5:1 floor, so the widget's
+   own heading read as a dark-violet-on-dark smudge. Reuse #a78bfa — the exact
+   dark violet this codebase already standardised for the same hue (the AI-tech
+   badges/titles, see §22 and custom.css .dark .ai-tech-badge) — so the widget
+   heading joins that established violet family: it resolves to 6.80:1 (EN) /
+   6.43:1 (ZH), clearing AA. body.dark-scoped (specificity 0,2,1 vs source
+   0,1,1, loaded last) so it wins in dark and is never selected in light —
+   light mode keeps #6b46c1, provably unchanged. */
+body.dark .widget-ai-projects h3,
+[data-theme="dark"] .widget-ai-projects h3 {
+  color: #a78bfa;
+}
+
+/* ── 29. Profile-panel AI icon tint (dark) ───────────────────────
+   The home profile panel's AI icon (layouts/partials/index_profile.html)
+   paints `.profile_panel__icon--ai { color: #6366f1 }` (indigo-500), un-gated.
+   As a non-text glyph it only needs the 3:1 contrast floor, which it clears on
+   the dark paper (4.14:1 EN / 3.92:1 ZH) — so this is NOT a failure — but at
+   that level the indigo reads dim and slightly muddy against the near-black
+   surface. Lift it one step to indigo-400 #818cf8 (6.20:1 EN / 5.86:1 ZH) so
+   the icon stays crisp and on-palette with the §28 / §22 violet family. Purely
+   a dark-only clarity nudge; body.dark-scoped (0,2,0 vs source 0,1,0, loaded
+   last) so light mode keeps #6366f1, provably unchanged. */
+body.dark .profile_panel__icon--ai,
+[data-theme="dark"] .profile_panel__icon--ai {
+  color: #818cf8;
+}

--- a/assets/css/extended/zz-dark-reading.css
+++ b/assets/css/extended/zz-dark-reading.css
@@ -1046,3 +1046,37 @@ body.dark .post-content :not(pre) > code,
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid var(--color-rule, rgba(226, 227, 225, 0.14));
 }
+
+/* ── 31. Related-posts card cover glare (dark) ───────────────────
+   Every image on an article is already tamed in dark: in-prose images
+   (§3, `.post-content img`) and the hero cover (§13,
+   `.post-single .entry-cover img`) each get a faint inset edge ring +
+   a slight brightness trim so a white-background diagram doesn't read
+   as a glaring block on the dark page. The "Related Posts" cards at the
+   foot of an article carry their OWN cover strip — `.rpc__cover img`,
+   which lives outside both `.post-content` and `.entry-cover`, so
+   neither rule reached it. A related post whose cover is a white-canvas
+   diagram (e.g. the "Vector Databases" thumbnail) therefore renders as
+   a hard, full-brightness white rectangle flush against the calm dark
+   `#1a1c1b` card — the single loudest surface in the footer, and the
+   one image class the dark pass had missed. Bring it into the same
+   already-proven family: a faint inset ring on the cover frame so the
+   bright strip has a crisp boundary against the card instead of bleeding
+   into it, and the identical brightness/contrast trim used in §3/§13 so
+   the glare is contained. True colour returns on hover — and the card's
+   existing `transform: scale(1.04)` hover (custom.css) is on a different
+   property, so both apply. Dark mode only; light keeps the cover
+   untouched, where a white canvas already blends with the light card. */
+body.dark .rpc__cover,
+[data-theme="dark"] .rpc__cover {
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+}
+body.dark .rpc__cover img,
+[data-theme="dark"] .rpc__cover img {
+  filter: brightness(0.94) contrast(1.02);
+  transition: transform 0.3s ease, filter 200ms ease;
+}
+body.dark .rpc:hover .rpc__cover img,
+[data-theme="dark"] .rpc:hover .rpc__cover img {
+  filter: brightness(1) contrast(1);
+}

--- a/assets/css/extended/zzz-card-title-draw.css
+++ b/assets/css/extended/zzz-card-title-draw.css
@@ -1,0 +1,107 @@
+/* ============================================================
+   zzz-card-title-draw.css — card title comes alive on hover
+   ------------------------------------------------------------
+   The article / homepage cards already lift on hover (custom.css,
+   homepage-daypage.css, zzz-press-feedback.css) — but the *title*
+   inside them stays completely static. With a mouse that lift reads
+   fine, yet the headline never signals "I am the link you're about
+   to open." This layer brings the title to life on pointer hover:
+   it shifts to the accent ink and a short accent underline draws in
+   from the left edge — the same "you are here / click me" idiom the
+   in-prose links (micro-interactions.css) and the deep-link landing
+   bar (interaction-polish.css) already use, so it feels native.
+
+   Design rules followed here (matching the rest of this codebase):
+   • Pointer-only: wrapped in `@media (hover: hover) and (pointer: fine)`
+     so it never fires from a touch tap (phones get the press-scale
+     from zzz-press-feedback.css instead — no phantom hover stuck on).
+   • Zero layout shift: the underline is an absolutely-positioned
+     ::after that scales on the X axis. It never reserves flow space,
+     so resting layout is byte-identical to before.
+   • Language-aware accent via --color-accent (EN sky/green, ZH
+     cinnabar; dark flips per tokens.css) — the same variable the
+     links already resolve, so light/dark/EN/ZH all read correctly.
+   • Loads late (zzz- prefix) and is fully neutralised under
+     prefers-reduced-motion at the bottom. Purely additive feedback —
+     never required for content to be read or navigated.
+   ============================================================ */
+
+/* The title elements across the card families that act as whole-card
+   links. Give each a positioning context for the underline and an
+   eased colour transition so the hover is a glide, not a jump. */
+.hp-post-card .hp-post-title,
+.hp-ai-card .hp-ai-card-title,
+.post-entry .entry-header h2 {
+  position: relative;
+  transition: color 0.22s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+/* The drawn underline: a short accent rule pinned to the title's
+   left edge. Kept to ~2.2em so it reads as a deliberate marker that
+   hugs the start of the headline rather than a full-width rule that
+   would overshoot short titles. Absolute + scaleX(0) at rest means it
+   occupies no space until it grows in. */
+.hp-post-card .hp-post-title::after,
+.hp-ai-card .hp-ai-card-title::after,
+.post-entry .entry-header h2::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: -0.18em;
+  width: 2.2em;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--color-accent, var(--primary));
+  transform: scaleX(0);
+  transform-origin: left center;
+  opacity: 0;
+  transition:
+    transform 0.32s cubic-bezier(0.22, 0.61, 0.36, 1),
+    opacity 0.32s ease;
+  pointer-events: none;
+}
+
+/* ---------- Pointer hover: light the title up ----------
+   Only fine pointers hover, so this is fenced off from touch. The
+   whole card is the hover target; the title responds. */
+@media (hover: hover) and (pointer: fine) {
+  .hp-post-card:hover .hp-post-title,
+  .hp-ai-card:hover .hp-ai-card-title,
+  .post-entry:hover .entry-header h2 {
+    color: var(--color-accent, var(--primary));
+  }
+  .hp-post-card:hover .hp-post-title::after,
+  .hp-ai-card:hover .hp-ai-card-title::after,
+  .post-entry:hover .entry-header h2::after {
+    transform: scaleX(1);
+    opacity: 1;
+  }
+}
+
+/* Keyboard parity: when the card link itself is focused (tab nav),
+   draw the same marker so keyboard users get the identical cue. The
+   featured homepage card and the article cards expose their link via
+   :focus-visible on the card / overlay anchor. */
+.hp-post-card:focus-visible .hp-post-title::after,
+.hp-ai-card:focus-visible .hp-ai-card-title::after,
+.post-entry:focus-within .entry-header h2::after {
+  transform: scaleX(1);
+  opacity: 1;
+}
+
+/* ============================================================
+   Reduced motion: drop the draw + colour glide entirely so the
+   experience is fully static for visitors who ask for it.
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .hp-post-card .hp-post-title,
+  .hp-ai-card .hp-ai-card-title,
+  .post-entry .entry-header h2 {
+    transition: none !important;
+  }
+  .hp-post-card .hp-post-title::after,
+  .hp-ai-card .hp-ai-card-title::after,
+  .post-entry .entry-header h2::after {
+    display: none !important;
+  }
+}

--- a/assets/css/extended/zzz-copy-code-feedback.css
+++ b/assets/css/extended/zzz-copy-code-feedback.css
@@ -48,6 +48,17 @@
     color-mix(in srgb, var(--color-accent, var(--primary)) 35%, transparent);
 }
 
+/* In dark mode the accent flips to light sky-blue (EN #7dd3fc) / red (ZH),
+   and white label + check (currentColor) on the light-blue fill collapse to
+   ~1.67:1. Paint the on-accent foreground with the page paper tone instead —
+   dark ink on the light dark-accent reads at 11:1 (EN) / 6.3:1 (ZH). `.dark`
+   wins specificity over the base; `!important` matches the base declaration.
+   Gated on .dark — light mode (dark accent) keeps the white label. */
+.dark .post-content .highlight .copy-code.is-copied,
+.dark .post-content pre .copy-code.is-copied {
+  color: var(--color-paper) !important;
+}
+
 /* A small check that slips in ahead of the "copied!" label. */
 .post-content .highlight .copy-code.is-copied::before,
 .post-content pre .copy-code.is-copied::before {

--- a/assets/css/extended/zzz-footnote-preview.css
+++ b/assets/css/extended/zzz-footnote-preview.css
@@ -1,0 +1,179 @@
+/* ============================================================
+   zzz-footnote-preview.css — inline footnote preview card
+   ------------------------------------------------------------
+   Floats a small card with a footnote's text when the reader
+   hovers / focuses (desktop) or taps (mobile) a reference marker,
+   so a citation can be checked without jumping to the endnotes and
+   losing one's place. Behaviour + positioning live in
+   static/js/footnote-preview.js; this is purely presentation.
+
+   Theme-aware via the shared design tokens (paper, ink, rule,
+   accent, shadow), so it reads correctly in every light/dark
+   palette. The entrance motion is gated behind
+   prefers-reduced-motion: no-preference — the card still appears
+   for motion-averse visitors, just without the rise/scale, because
+   it carries information rather than decoration.
+
+   Loads last in the extended bundle (zzz- prefix).
+   ============================================================ */
+
+.fn-popover {
+  position: absolute;
+  z-index: 1200;
+  /* Comfortable reading column for a note, clamped on small screens. */
+  width: max-content;
+  max-width: min(360px, calc(100vw - 24px));
+  box-sizing: border-box;
+  padding: 0.7rem 0.85rem 0.6rem;
+  background: var(--color-bg, #f9f9f7);
+  color: var(--color-text, #1a1c1b);
+  border: 1px solid var(--color-border, rgba(30, 35, 30, 0.12));
+  border-radius: var(--radius-lg, 12px);
+  box-shadow: var(--shadow-lg, 0 12px 32px rgba(15, 23, 42, 0.08));
+  font-family: var(--font-prose, var(--font-serif, Georgia, serif));
+  font-size: 0.86rem;
+  line-height: 1.5;
+
+  /* Hidden resting state. Opacity + visibility so it's removed from the
+     a11y tree and never intercepts pointer events while closed. */
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(4px);
+  transition: opacity 0.16s ease, transform 0.18s cubic-bezier(0.22, 0.61, 0.36, 1),
+    visibility 0s linear 0.18s;
+}
+
+.fn-popover.is-visible {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition: opacity 0.18s ease, transform 0.2s cubic-bezier(0.22, 0.61, 0.36, 1),
+    visibility 0s;
+}
+
+/* The note's text. Tame block margins so a one-line note isn't padded
+   like a full article paragraph, and keep long links from overflowing. */
+.fn-popover__body > :first-child { margin-top: 0; }
+.fn-popover__body > :last-child { margin-bottom: 0; }
+.fn-popover__body p { margin: 0 0 0.4rem; }
+.fn-popover__body a {
+  color: var(--color-accent, #2e352e);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  word-break: break-word;
+}
+.fn-popover__body code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.92em;
+}
+
+/* "Go to note ↓" — quiet affordance, mostly for touch where the tap no
+   longer jumps on its own. Hidden on hover-capable pointers to keep the
+   desktop card clean (kept in the DOM for keyboard users via :focus). */
+.fn-popover__more {
+  display: inline-block;
+  margin-top: 0.15rem;
+  font-family: var(--font-meta, var(--font-sans, system-ui, sans-serif));
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  color: var(--color-text-muted, #5e5e63);
+  text-decoration: none;
+  opacity: 0.9;
+}
+.fn-popover__more:hover,
+.fn-popover__more:focus { color: var(--color-accent, #2e352e); }
+
+@media (hover: hover) and (pointer: fine) {
+  .fn-popover__more { display: none; }
+  .fn-popover__more:focus { display: inline-block; }
+}
+
+/* Little arrow pointing at the marker. --fn-arrow-x is set in JS. */
+.fn-popover::after {
+  content: "";
+  position: absolute;
+  left: var(--fn-arrow-x, 50%);
+  width: 10px;
+  height: 10px;
+  background: var(--color-bg, #f9f9f7);
+  border: 1px solid var(--color-border, rgba(30, 35, 30, 0.12));
+  transform: translateX(-50%) rotate(45deg);
+}
+/* Card above the marker → arrow on its bottom edge (top borders hidden). */
+.fn-popover:not(.is-below)::after {
+  bottom: -6px;
+  border-top: none;
+  border-left: none;
+}
+/* Card below the marker → arrow on its top edge. */
+.fn-popover.is-below::after {
+  top: -6px;
+  border-bottom: none;
+  border-right: none;
+}
+
+/* Give the reference marker a clear "interactive" feel: a subtle pill on
+   hover/focus so readers discover the preview affordance. */
+.post-content a.footnote-ref {
+  border-radius: 4px;
+  padding: 0 0.12em;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.post-content a.footnote-ref:hover,
+.post-content a.footnote-ref:focus-visible {
+  background: var(--color-accent-soft, #dde5da);
+}
+
+/* On touch screens there's no hover to reveal that a marker is
+   previewable, so give it a quiet resting affordance: a faint dotted
+   underline — the long-standing "there's more here" convention. Uses
+   text-decoration only (never transform/border), so it adds no reflow
+   to the superscript. The marker still falls back to a plain in-page
+   anchor with JS off. */
+@media (hover: none) and (pointer: coarse) {
+  .post-content a.footnote-ref {
+    text-decoration: underline dotted;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+    text-decoration-color: color-mix(
+      in srgb,
+      var(--color-accent, currentColor) 45%,
+      transparent
+    );
+  }
+}
+
+/* ── Dark mode: lift the card off the page ───────────────────────
+   The resting fill is var(--color-bg), which in dark mode IS the page
+   paper (#121413 EN / #1c1917 ZH). The dark --shadow-lg is a near-black
+   ambient shadow, so on a near-black page it does almost nothing and the
+   1px / 10%-opacity border is barely visible — the floating note reads
+   flat against the page. Mirror the idiom used by .article-tldr: lift the
+   surface with a faint white overlay (Material-style elevation), firm up
+   the border, add a quiet top bevel + a deeper ambient shadow so the card
+   clearly hovers. The arrow is lifted to the same surface so its tip
+   doesn't read as a darker notch. Gated on .dark — light mode keeps the
+   token-driven paper fill and soft shadow untouched. */
+.dark .fn-popover {
+  --fn-surface: color-mix(in srgb, #ffffff 5%, var(--color-bg, #121413));
+  background: var(--fn-surface);
+  border-color: rgba(255, 255, 255, 0.16);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 18px 44px -22px rgba(0, 0, 0, 0.72);
+}
+.dark .fn-popover::after {
+  background: var(--fn-surface, var(--color-bg, #121413));
+  border-color: rgba(255, 255, 255, 0.16);
+}
+
+/* Reduced motion: keep the card (it's informational) but drop the rise. */
+@media (prefers-reduced-motion: reduce) {
+  .fn-popover,
+  .fn-popover.is-visible {
+    transform: none;
+    transition: opacity 0.12s ease, visibility 0s;
+  }
+}

--- a/assets/css/extended/zzz-press-feedback.css
+++ b/assets/css/extended/zzz-press-feedback.css
@@ -32,7 +32,12 @@
 .hp-book,
 .hp-project-featured,
 .hp-repo,
-.hp-posts-list-row {
+.hp-posts-list-row,
+/* Related-post cards (rpc) at the foot of an article are whole-card
+   links too. They lift/shift their arrow on hover but had no press
+   response, so a tap on a phone navigated with no tactile beat — bring
+   them into the same family. */
+.rpc {
   /* Replace the default grey tap-flash on mobile with our own scale
      cue so the press reads as intentional, not like a mis-tap. */
   -webkit-tap-highlight-color: transparent;
@@ -53,7 +58,8 @@
   .hp-book:active,
   .hp-project-featured:active,
   .hp-repo:active,
-  .hp-posts-list-row:active {
+  .hp-posts-list-row:active,
+  .rpc:active {
     transform: translateY(0) scale(0.985);
     transition: transform 0.1s ease;
   }
@@ -73,7 +79,8 @@
   .hp-book:active,
   .hp-project-featured:active,
   .hp-repo:active,
-  .hp-posts-list-row:active {
+  .hp-posts-list-row:active,
+  .rpc:active {
     transform: scale(0.97);
     transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
   }
@@ -115,6 +122,7 @@
   .hp-project-featured:active,
   .hp-repo:active,
   .hp-posts-list-row:active,
+  .rpc:active,
   #menu > li > a:active,
   .nav-search-trigger:active {
     transform: none !important;

--- a/config.yml
+++ b/config.yml
@@ -146,12 +146,60 @@ markup:
   goldmark:
     renderer:
       unsafe: true
+
+# Hugo internal services configuration
+services:
+  rss:
+    # -1 = include all pages, no cap. Default would silently truncate large sites.
+    limit: -1
+
+# Custom media types & output formats: JSON Feed 1.1 + OPML subscription list.
+mediaTypes:
+  application/feed+json:
+    suffixes: ["json"]
+  text/x-opml:
+    suffixes: ["opml"]
+
+outputFormats:
+  JSONFeed:
+    name: JSONFeed
+    mediaType: application/feed+json
+    baseName: feed
+    isPlainText: true
+    rel: alternate
+    notAlternative: false
+  OPML:
+    name: OPML
+    mediaType: text/x-opml
+    baseName: subscriptions
+    isPlainText: true
+    rel: alternate
+    notAlternative: false
+  # News sitemap for posts published within last 2 days (Google News spec)
+  NewsSitemap:
+    name: NewsSitemap
+    mediaType: application/xml
+    baseName: news-sitemap
+    isPlainText: false
+    rel: sitemap
+    notAlternative: true
+
 outputs:
     home:
       - HTML
       - RSS
-      - JSON # is necessary
+      - JSON           # search index
+      - JSONFeed       # JSON Feed 1.1 at /feed.json
+      - OPML           # /subscriptions.opml
+      - NewsSitemap    # /news-sitemap.xml
     section:
+      - HTML
+      - RSS
+      - JSONFeed
+    taxonomy:
+      - HTML
+      - RSS
+    term:
       - HTML
       - RSS
 

--- a/layouts/_default/list.jsonfeed.json
+++ b/layouts/_default/list.jsonfeed.json
@@ -1,0 +1,87 @@
+{{- /*
+  JSON Feed 1.1 — https://jsonfeed.org/version/1.1
+  Output: /feed.json (home), /<section>/feed.json (sections)
+  Honors services.rss.limit (-1 = all pages).
+*/ -}}
+{{- $pages := slice -}}
+{{- if $.IsHome -}}
+  {{- $pages = site.RegularPages -}}
+{{- else if $.IsSection -}}
+  {{- $pages = .RegularPages -}}
+{{- else -}}
+  {{- $pages = .Pages -}}
+{{- end -}}
+{{- $limit := site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+  {{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- $excludedLayouts := slice "search" "archives" "categories" -}}
+{{- $items := slice -}}
+{{- range $pages -}}
+  {{- if in $excludedLayouts .Layout }}{{ continue }}{{ end -}}
+  {{- if .Params.private }}{{ continue }}{{ end -}}
+  {{- if .Params.robotsNoIndex }}{{ continue }}{{ end -}}
+  {{- $coverURL := "" -}}
+  {{- with .Params.cover -}}
+    {{- with .image -}}
+      {{- if or (hasPrefix . "http://") (hasPrefix . "https://") -}}
+        {{- $coverURL = . -}}
+      {{- else if hasPrefix . "/" -}}
+        {{- $coverURL = . | absURL -}}
+      {{- else -}}
+        {{- with $.Resources.GetMatch . -}}{{- $coverURL = .Permalink -}}
+        {{- else -}}
+          {{- with resources.GetMatch . -}}{{- $coverURL = .Permalink -}}
+          {{- else -}}{{- $coverURL = . | absURL -}}{{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $summary := "" -}}
+  {{- with .Description -}}{{- $summary = . -}}
+  {{- else -}}{{- $summary = .Summary | plainify -}}
+  {{- end -}}
+  {{- $item := dict
+      "id" .Permalink
+      "url" .Permalink
+      "title" .Title
+      "summary" $summary
+      "date_published" (.Date.Format "2006-01-02T15:04:05Z07:00")
+      "language" site.Language.LanguageCode
+  -}}
+  {{- if not .Lastmod.IsZero -}}
+    {{- $item = merge $item (dict "date_modified" (.Lastmod.Format "2006-01-02T15:04:05Z07:00")) -}}
+  {{- end -}}
+  {{- if site.Params.ShowFullTextinRSS -}}
+    {{- $item = merge $item (dict "content_html" .Content) -}}
+  {{- else -}}
+    {{- $item = merge $item (dict "content_text" $summary) -}}
+  {{- end -}}
+  {{- with site.Params.author -}}
+    {{- $author := dict "name" . -}}
+    {{- with site.Params.email -}}{{- $author = merge $author (dict "url" (printf "mailto:%s" .)) -}}{{- end -}}
+    {{- $item = merge $item (dict "authors" (slice $author)) -}}
+  {{- end -}}
+  {{- $allTags := slice -}}
+  {{- range .Params.categories -}}{{- $allTags = $allTags | append . -}}{{- end -}}
+  {{- range .Params.tags -}}{{- $allTags = $allTags | append . -}}{{- end -}}
+  {{- if $allTags -}}{{- $item = merge $item (dict "tags" $allTags) -}}{{- end -}}
+  {{- if $coverURL -}}{{- $item = merge $item (dict "image" $coverURL) -}}{{- end -}}
+  {{- $items = $items | append $item -}}
+{{- end -}}
+{{- $feed := dict
+    "version" "https://jsonfeed.org/version/1.1"
+    "title" (cond (eq .Title site.Title) site.Title (printf "%s on %s" .Title site.Title))
+    "home_page_url" .Permalink
+    "language" site.Language.LanguageCode
+    "items" $items
+-}}
+{{- with .OutputFormats.Get "JSONFeed" -}}{{- $feed = merge $feed (dict "feed_url" .Permalink) -}}{{- end -}}
+{{- with site.Params.description -}}{{- $feed = merge $feed (dict "description" .) -}}{{- end -}}
+{{- with site.Params.images -}}{{- $feed = merge $feed (dict "icon" (index . 0 | absURL)) -}}{{- end -}}
+{{- with site.Params.author -}}
+  {{- $author := dict "name" . -}}
+  {{- with site.Params.email -}}{{- $author = merge $author (dict "url" (printf "mailto:%s" .)) -}}{{- end -}}
+  {{- $feed = merge $feed (dict "authors" (slice $author)) -}}
+{{- end -}}
+{{- $feed | jsonify (dict "indent" "  ") -}}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -1,0 +1,113 @@
+{{- /*
+  Custom RSS 2.0 template — supersedes PaperMod default.
+  Adds: <category>, <enclosure> (cover image), media:content, dc:creator,
+        language-aware channel, full pages on home / regular pages on section.
+  Behavior: summary mode (ShowFullTextinRSS=false).
+  Limit: services.rss.limit = -1 (config.yml) → emits all pages.
+*/ -}}
+{{- $pctx := . -}}
+{{- if .IsHome -}}{{ $pctx = site }}{{- end -}}
+{{- $pages := slice -}}
+{{- if or $.IsHome $.IsSection -}}
+  {{- $pages = $pctx.RegularPages -}}
+{{- else -}}
+  {{- $pages = $pctx.Pages -}}
+{{- end -}}
+{{- $limit := site.Config.Services.RSS.Limit -}}
+{{- if ge $limit 1 -}}
+  {{- $pages = $pages | first $limit -}}
+{{- end -}}
+{{- $excludedLayouts := slice "search" "archives" "categories" -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/"
+     xmlns:media="http://search.yahoo.com/mrss/">
+  <channel>
+    <title>{{ if eq .Title site.Title }}{{ site.Title }}{{ else }}{{ with .Title }}{{ . }} on {{ end }}{{ site.Title }}{{ end }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>{{ with site.Params.description }}{{ . }}{{ else }}Recent content {{ if ne .Title site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ site.Title }}{{ end }}</description>
+    {{- with site.Params.images }}
+    <image>
+      <title>{{ site.Title }}</title>
+      <url>{{ index . 0 | absURL }}</url>
+      <link>{{ site.BaseURL }}</link>
+    </image>
+    {{- end }}
+    <generator>Hugo -- gohugo.io</generator>
+    {{- with site.LanguageCode }}
+    <language>{{ . }}</language>
+    {{- end }}
+    {{- with site.Params.email }}
+    <managingEditor>{{ . }}{{ with site.Params.author }} ({{ . }}){{ end }}</managingEditor>
+    <webMaster>{{ . }}{{ with site.Params.author }} ({{ . }}){{ end }}</webMaster>
+    {{- end }}
+    {{- with site.Copyright }}
+    <copyright>{{ . }}</copyright>
+    {{- end }}
+    {{- if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>
+    {{- end }}
+    {{- with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{- end }}
+    {{- range $pages }}
+      {{- if in $excludedLayouts .Layout }}{{ continue }}{{ end }}
+      {{- if .Params.private }}{{ continue }}{{ end }}
+      {{- if .Params.robotsNoIndex }}{{ continue }}{{ end }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{- if not .Lastmod.IsZero }}
+      <atom:updated>{{ .Lastmod.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</atom:updated>
+      {{- end }}
+      {{- with site.Params.email }}
+      <author>{{ . }}{{ with site.Params.author }} ({{ . }}){{ end }}</author>
+      {{- end }}
+      {{- with site.Params.author }}
+      <dc:creator>{{ . }}</dc:creator>
+      {{- end }}
+      <guid isPermaLink="true">{{ .Permalink }}</guid>
+      <description>{{ with .Description }}{{ . | html }}{{ else }}{{ .Summary | plainify | htmlEscape | safeHTML }}{{ end }}</description>
+      {{- if site.Params.ShowFullTextinRSS }}
+      <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
+      {{- end }}
+      {{- range .Params.categories }}
+      <category domain="category">{{ . }}</category>
+      {{- end }}
+      {{- range .Params.tags }}
+      <category domain="tag">{{ . }}</category>
+      {{- end }}
+      {{- /* Cover image → <enclosure> + <media:content> */ -}}
+      {{- $coverURL := "" -}}
+      {{- with .Params.cover }}
+        {{- with .image }}
+          {{- if or (hasPrefix . "http://") (hasPrefix . "https://") -}}
+            {{- $coverURL = . -}}
+          {{- else if hasPrefix . "/" -}}
+            {{- $coverURL = . | absURL -}}
+          {{- else -}}
+            {{- with $.Resources.GetMatch . -}}
+              {{- $coverURL = .Permalink -}}
+            {{- else -}}
+              {{- with resources.GetMatch . -}}
+                {{- $coverURL = .Permalink -}}
+              {{- else -}}
+                {{- $coverURL = . | absURL -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end }}
+      {{- end }}
+      {{- if $coverURL }}
+      <enclosure url="{{ $coverURL }}" type="image/jpeg" length="0" />
+      <media:content url="{{ $coverURL }}" medium="image">
+        {{- with .Params.cover.alt }}<media:description>{{ . | plainify }}</media:description>{{ end -}}
+      </media:content>
+      {{- end }}
+    </item>
+    {{- end }}
+  </channel>
+</rss>

--- a/layouts/index.newssitemap.xml
+++ b/layouts/index.newssitemap.xml
@@ -1,0 +1,34 @@
+{{- /*
+  Google News sitemap — https://developers.google.com/search/docs/crawling-indexing/sitemaps/news-sitemap
+  Output: /news-sitemap.xml (per language).
+  Includes only articles published within the last 2 days, per Google spec.
+*/ -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+  {{- $cutoff := now.AddDate 0 0 -2 -}}
+  {{- $excludedLayouts := slice "search" "archives" "categories" -}}
+  {{- range site.RegularPages -}}
+    {{- if .Date.Before $cutoff }}{{ continue }}{{ end -}}
+    {{- if .Params.private }}{{ continue }}{{ end -}}
+    {{- if .Params.robotsNoIndex }}{{ continue }}{{ end -}}
+    {{- if in $excludedLayouts .Layout }}{{ continue }}{{ end -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>
+    <news:news>
+      <news:publication>
+        <news:name>{{ site.Title }}</news:name>
+        <news:language>{{ site.Language.Lang }}</news:language>
+      </news:publication>
+      <news:publication_date>{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}</news:publication_date>
+      <news:title>{{ .Title }}</news:title>
+      {{- $kw := slice -}}
+      {{- range .Params.tags -}}{{- $kw = $kw | append . -}}{{- end -}}
+      {{- range .Params.categories -}}{{- $kw = $kw | append . -}}{{- end -}}
+      {{- with $kw }}
+      <news:keywords>{{ delimit . ", " }}</news:keywords>
+      {{- end }}
+    </news:news>
+  </url>
+  {{- end }}
+</urlset>

--- a/layouts/index.opml.opml
+++ b/layouts/index.opml.opml
@@ -1,0 +1,43 @@
+{{- /*
+  OPML 2.0 — subscription bundle for all section RSS feeds.
+  Output: /subscriptions.opml (per language).
+  Lets readers one-click import every section feed into their RSS reader.
+  isPlainText: true → must manually XML-escape any text containing &, <, >.
+*/ -}}
+{{- printf "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" | safeHTML }}
+{{- $siteTitle := transform.XMLEscape site.Title -}}
+<opml version="2.0">
+  <head>
+    <title>{{ $siteTitle }} — Subscriptions</title>
+    <dateCreated>{{ now.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}</dateCreated>
+    {{- with site.Params.author }}
+    <ownerName>{{ transform.XMLEscape . }}</ownerName>
+    {{- end }}
+    {{- with site.Params.email }}
+    <ownerEmail>{{ transform.XMLEscape . }}</ownerEmail>
+    {{- end }}
+  </head>
+  <body>
+    <outline title="{{ $siteTitle }}" text="{{ $siteTitle }}">
+      {{- /* Site-wide RSS first */ -}}
+      {{- with .OutputFormats.Get "RSS" }}
+      <outline type="rss"
+               text="{{ $siteTitle }} — All Posts"
+               title="{{ $siteTitle }} — All Posts"
+               xmlUrl="{{ .Permalink }}"
+               htmlUrl="{{ site.BaseURL }}" />
+      {{- end }}
+      {{- /* Per-section RSS */ -}}
+      {{- range site.Sections }}
+        {{- $sectionTitle := transform.XMLEscape (.Title | default .Section) -}}
+        {{- with .OutputFormats.Get "RSS" }}
+      <outline type="rss"
+               text="{{ $sectionTitle }}"
+               title="{{ $sectionTitle }}"
+               xmlUrl="{{ .Permalink }}"
+               htmlUrl="{{ $.Permalink }}" />
+        {{- end }}
+      {{- end }}
+    </outline>
+  </body>
+</opml>

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -25,5 +25,6 @@
 <script src="{{ "/js/toc-highlight.js" | relURL }}" defer></script>
 <script src="{{ "/js/image-lightbox.js" | relURL }}" defer></script>
 <script src="{{ "/js/wide-content-scroll.js" | relURL }}" defer></script>
+<script src="{{ "/js/footnote-preview.js" | relURL }}" defer></script>
 {{- end }}
 {{ partial "search-palette.html" . }}

--- a/layouts/partials/homepage-daypage.html
+++ b/layouts/partials/homepage-daypage.html
@@ -352,8 +352,34 @@
             <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.18 15.64a2.18 2.18 0 0 1 2.18 2.18C8.36 19.01 7.38 20 6.18 20C4.98 20 4 19.01 4 17.82a2.18 2.18 0 0 1 2.18-2.18M4 4.44A15.56 15.56 0 0 1 19.56 20h-2.83A12.73 12.73 0 0 0 4 7.27V4.44m0 5.66a9.9 9.9 0 0 1 9.9 9.9h-2.83A7.07 7.07 0 0 0 4 12.93V10.1z"/></svg>
             RSS
           </a>
+          {{- with (site.GetPage "/").OutputFormats.Get "JSONFeed" }}
+          <a class="hp-subscribe-rss" href="{{ .RelPermalink }}" target="_blank" rel="noopener" title="JSON Feed 1.1">JSON</a>
+          {{- end }}
+          {{- with (site.GetPage "/").OutputFormats.Get "OPML" }}
+          <a class="hp-subscribe-rss" href="{{ .RelPermalink }}" download title="{{ if $isZh }}OPML 订阅集 — 导入到任意 RSS 阅读器{{ else }}OPML — import all channels into any reader{{ end }}">OPML</a>
+          {{- end }}
         </div>
       </form>
+
+      {{/* ── By-channel feeds (compact, magazine-style) ── */}}
+      <div class="hp-subscribe-channels">
+        <span class="hp-subscribe-channels-label">{{ if $isZh }}按频道订阅{{ else }}By channel{{ end }}</span>
+        <div class="hp-subscribe-channels-list">
+          {{- $colors := slice "#3b82f6" "#10b981" "#a855f7" "#ec4899" "#06b6d4" "#eab308" -}}
+          {{- range $i, $section := site.Sections -}}
+            {{- $rss := $section.OutputFormats.Get "RSS" -}}
+            {{- if $rss -}}
+              {{- $title := $section.Title | default $section.Section -}}
+              {{- $color := index $colors (mod $i (len $colors)) }}
+          <a class="hp-channel-pill" href="{{ $rss.RelPermalink }}" target="_blank" rel="noopener" title="RSS · {{ $title }}" style="--ch-color: {{ $color }}">
+            <span class="hp-channel-pill-dot" aria-hidden="true"></span>
+            <span class="hp-channel-pill-name">{{ $title }}</span>
+            <span class="hp-channel-pill-fmt">RSS</span>
+          </a>
+            {{- end -}}
+          {{- end }}
+        </div>
+      </div>
     </div>
 
   </main>
@@ -392,6 +418,12 @@
           <li><a href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer">{{ .title | default (.name | title) }}</a></li>
           {{- end }}
           <li><a href="{{ "/index.xml" | relLangURL }}">RSS</a></li>
+          {{- with (site.GetPage "/").OutputFormats.Get "JSONFeed" }}
+          <li><a href="{{ .RelPermalink }}">JSON Feed</a></li>
+          {{- end }}
+          {{- with (site.GetPage "/").OutputFormats.Get "OPML" }}
+          <li><a href="{{ .RelPermalink }}" download>OPML (all)</a></li>
+          {{- end }}
         </ul>
       </div>
     </div>

--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -9,11 +9,29 @@
     {{- range . -}}
     {{- $tags := .Params.tags -}}
     {{- $cover := .Params.cover -}}
-    {{- $hasCover := and $cover $cover.image -}}
+    {{- $coverURL := "" -}}
+    {{- with $cover -}}
+      {{- with .image -}}
+        {{- if or (hasPrefix . "http://") (hasPrefix . "https://") (hasPrefix . "/") -}}
+          {{- $coverURL = . -}}
+        {{- else -}}
+          {{- with $.Resources.GetMatch . -}}
+            {{- $coverURL = .RelPermalink -}}
+          {{- else -}}
+            {{- with resources.GetMatch . -}}
+              {{- $coverURL = .RelPermalink -}}
+            {{- else -}}
+              {{- $coverURL = relURL . -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $hasCover := ne $coverURL "" -}}
     <a href="{{ .RelPermalink }}" class="rpc{{- if $hasCover }} rpc--has-cover{{- end }}">
       {{- if $hasCover -}}
       <div class="rpc__cover" aria-hidden="true">
-        <img src="{{ $cover.image }}" alt="" loading="lazy" decoding="async">
+        <img src="{{ $coverURL }}" alt="" loading="lazy" decoding="async">
       </div>
       {{- end -}}
       <div class="rpc__body">

--- a/layouts/partials/rss-subscribe.html
+++ b/layouts/partials/rss-subscribe.html
@@ -6,6 +6,9 @@
 {{- $rssTitle       := cond $isZH "RSS 订阅" "Subscribe via RSS" -}}
 {{- $rssDescription := cond $isZH "第一时间获取最新文章通知，支持所有 RSS 阅读器。" "Get the latest posts delivered right to your RSS reader." -}}
 {{- $rssButtonText  := cond $isZH "打开 RSS Feed" "Open RSS Feed" -}}
+{{- $rssChannelsLabel := cond $isZH "或按频道订阅" "Or subscribe by channel" -}}
+{{- $rssAllLabel      := cond $isZH "全部文章" "All Posts" -}}
+{{- $rssOpmlHint      := cond $isZH "OPML 一键导入全部频道" "OPML — import all channels at once" -}}
 {{- $emailTitle     := cond $isZH "邮件订阅" "Email Newsletter" -}}
 {{- $emailDescription := cond $isZH "新文章和月度思考将通过邮件发送给你。默认双重确认，可随时退订。" "Get new posts and monthly notes by email. Double opt-in by default, unsubscribe anytime." -}}
 {{- $emailPlaceholder := "you@example.com" -}}
@@ -88,6 +91,41 @@
         </svg>
         {{ $rssButtonText }}
       </a>
+
+      {{/* ── Channel list: subscribe by section + JSON Feed + OPML ── */}}
+      {{- $homeJSON := (site.GetPage "/").OutputFormats.Get "JSONFeed" -}}
+      {{- $homeOPML := (site.GetPage "/").OutputFormats.Get "OPML" -}}
+      {{- $colors := slice "#3b82f6" "#10b981" "#a855f7" "#ec4899" "#06b6d4" "#eab308" -}}
+      <div class="rss-channels" role="list">
+        <p class="rss-channels__label">{{ $rssChannelsLabel }}</p>
+
+        <div class="rss-channels__row rss-channels__row--all" role="listitem">
+          <span class="rss-channels__dot" style="--ch-color: #f97316" aria-hidden="true"></span>
+          <span class="rss-channels__name">{{ $rssAllLabel }}</span>
+          <span class="rss-channels__formats">
+            <a href="{{ "/index.xml" | relLangURL }}" class="rss-channels__chip rss-channels__chip--rss" target="_blank" rel="noopener noreferrer" aria-label="RSS — {{ $rssAllLabel }}">RSS</a>
+            {{- with $homeJSON }}<a href="{{ .RelPermalink }}" class="rss-channels__chip rss-channels__chip--json" target="_blank" rel="noopener noreferrer" aria-label="JSON Feed — {{ $rssAllLabel }}">JSON</a>{{- end }}
+            {{- with $homeOPML }}<a href="{{ .RelPermalink }}" class="rss-channels__chip rss-channels__chip--opml" download title="{{ $rssOpmlHint }}" aria-label="{{ $rssOpmlHint }}">OPML</a>{{- end }}
+          </span>
+        </div>
+
+        {{- range $i, $section := site.Sections -}}
+          {{- $rss := $section.OutputFormats.Get "RSS" -}}
+          {{- $json := $section.OutputFormats.Get "JSONFeed" -}}
+          {{- $title := $section.Title | default $section.Section -}}
+          {{- $color := index $colors (mod $i (len $colors)) -}}
+          {{- if $rss }}
+        <div class="rss-channels__row" role="listitem">
+          <span class="rss-channels__dot" style="--ch-color: {{ $color }}" aria-hidden="true"></span>
+          <a href="{{ $section.RelPermalink }}" class="rss-channels__name rss-channels__name--link" title="{{ $title }}">{{ $title }}</a>
+          <span class="rss-channels__formats">
+            <a href="{{ $rss.RelPermalink }}" class="rss-channels__chip rss-channels__chip--rss" target="_blank" rel="noopener noreferrer" aria-label="RSS — {{ $title }}">RSS</a>
+            {{- with $json }}<a href="{{ .RelPermalink }}" class="rss-channels__chip rss-channels__chip--json" target="_blank" rel="noopener noreferrer" aria-label="JSON Feed — {{ $title }}">JSON</a>{{- end }}
+          </span>
+        </div>
+          {{- end -}}
+        {{- end }}
+      </div>
     </div>
   </div>
 

--- a/layouts/robots.txt
+++ b/layouts/robots.txt
@@ -26,3 +26,4 @@ User-agent: LinkedInBot
 Allow: /
 
 Sitemap: {{ "sitemap.xml" | absURL }}
+Sitemap: {{ "news-sitemap.xml" | absURL }}

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -43,9 +43,29 @@
     <priority>0.7</priority>
     {{- end }}
     {{- with .Params.cover.image -}}
-    {{- if not (hasPrefix . "http") }}
+    {{- $imgURL := "" -}}
+    {{- if or (hasPrefix . "http://") (hasPrefix . "https://") -}}
+      {{- $imgURL = . -}}
+    {{- else if hasPrefix . "/" -}}
+      {{- $imgURL = . | absURL -}}
+    {{- else -}}
+      {{- with $page.Resources.GetMatch . -}}
+        {{- $imgURL = .Permalink -}}
+      {{- else -}}
+        {{- with resources.GetMatch . -}}
+          {{- $imgURL = .Permalink -}}
+        {{- else -}}
+          {{- $imgURL = . | absURL -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $imgURL }}
     <image:image>
-      <image:loc>{{ . | absURL }}</image:loc>
+      <image:loc>{{ $imgURL }}</image:loc>
+      <image:title>{{ $page.Title }}</image:title>
+      {{- with $page.Params.cover.alt }}
+      <image:caption>{{ . | plainify }}</image:caption>
+      {{- end }}
     </image:image>
     {{- end -}}
     {{- end -}}

--- a/layouts/sitemapindex.xml
+++ b/layouts/sitemapindex.xml
@@ -57,10 +57,32 @@
     {{- else }}
     <priority>0.7</priority>
     {{- end }}
-    {{- if .Params.cover.image }}
+    {{- with .Params.cover.image }}
+    {{- $imgURL := "" -}}
+    {{- if or (hasPrefix . "http://") (hasPrefix . "https://") -}}
+      {{- $imgURL = . -}}
+    {{- else if hasPrefix . "/" -}}
+      {{- $imgURL = . | absURL -}}
+    {{- else -}}
+      {{- with $page.Resources.GetMatch . -}}
+        {{- $imgURL = .Permalink -}}
+      {{- else -}}
+        {{- with resources.GetMatch . -}}
+          {{- $imgURL = .Permalink -}}
+        {{- else -}}
+          {{- $imgURL = . | absURL -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+    {{- if $imgURL }}
     <image:image>
-      <image:loc>{{ .Params.cover.image | absURL }}</image:loc>
+      <image:loc>{{ $imgURL }}</image:loc>
+      <image:title>{{ $page.Title }}</image:title>
+      {{- with $page.Params.cover.alt }}
+      <image:caption>{{ . | plainify }}</image:caption>
+      {{- end }}
     </image:image>
+    {{- end -}}
     {{- end }}
     {{- if .IsTranslated }}
     {{- range .AllTranslations }}

--- a/static/js/footnote-preview.js
+++ b/static/js/footnote-preview.js
@@ -1,0 +1,252 @@
+/* ============================================================
+ * footnote-preview.js
+ * Inline footnote previews — see a citation without losing your
+ * place in the read.
+ *
+ *  • Desktop / mouse + keyboard: hovering or focusing a footnote
+ *    reference [n] floats a small card with the note's text,
+ *    anchored to the marker. Move away (or press Esc) to dismiss.
+ *  • Mobile / touch: the first tap on a reference opens the card
+ *    instead of jumping to the endnotes (you keep your spot); a
+ *    "go to note" link inside still takes you down if you want the
+ *    full context. Tapping the marker again or anywhere else closes
+ *    it. A second tap on the same marker follows the link.
+ *
+ * Progressive enhancement: with no JS the references are ordinary
+ * in-page anchors and behave exactly as before. One shared popover
+ * element is reused for every marker. Motion (the small rise/scale)
+ * only runs when the visitor allows it; the card itself still works
+ * under reduced-motion because it carries information, not flourish.
+ * Styling lives in zzz-footnote-preview.css.
+ * ========================================================== */
+(function () {
+  'use strict';
+
+  var content = document.querySelector('.post-content');
+  if (!content) return;
+
+  var refs = content.querySelectorAll('a.footnote-ref[href^="#"]');
+  if (!refs.length) return;
+
+  var prefersReduced =
+    window.matchMedia &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  // Coarse pointer (phones / tablets) → tap-to-open; otherwise hover.
+  var isTouch =
+    (window.matchMedia && window.matchMedia('(hover: none)').matches) ||
+    'ontouchstart' in window;
+
+  var isZh =
+    (document.documentElement.lang || '').toLowerCase().indexOf('zh') === 0;
+
+  /* --- One shared popover, lazily built ----------------------------- */
+  var pop = null;
+  var popBody = null;
+  var popMore = null;
+  var currentRef = null; // marker the popover is bound to right now
+  var showTimer = 0;
+  var hideTimer = 0;
+  var popId = 'fn-preview-popover';
+
+  function buildPop() {
+    if (pop) return pop;
+    pop = document.createElement('div');
+    pop.className = 'fn-popover';
+    pop.id = popId;
+    pop.setAttribute('role', 'tooltip');
+    pop.setAttribute('aria-hidden', 'true');
+
+    popBody = document.createElement('div');
+    popBody.className = 'fn-popover__body';
+    pop.appendChild(popBody);
+
+    popMore = document.createElement('a');
+    popMore.className = 'fn-popover__more';
+    popMore.textContent = isZh ? '查看脚注 ↓' : 'Go to note ↓';
+    pop.appendChild(popMore);
+
+    // Keep the card open while the pointer is inside it (desktop), so
+    // links/citations within the note can be clicked.
+    pop.addEventListener('mouseenter', function () {
+      window.clearTimeout(hideTimer);
+    });
+    pop.addEventListener('mouseleave', function () {
+      if (!isTouch) scheduleHide();
+    });
+
+    document.body.appendChild(pop);
+    return pop;
+  }
+
+  /* --- Extract a note's text from its <li id="fn:N"> ----------------- */
+  function noteHtmlFor(ref) {
+    var id = decodeURIComponent((ref.getAttribute('href') || '').slice(1));
+    if (!id) return null;
+    var def = document.getElementById(id);
+    if (!def) return null;
+    var clone = def.cloneNode(true);
+    // Drop the "return to text" back-references — they make no sense in
+    // a floating preview and would point the reader away.
+    clone.querySelectorAll('.footnote-backref').forEach(function (a) {
+      a.parentNode && a.parentNode.removeChild(a);
+    });
+    var html = clone.innerHTML.trim();
+    return html || null;
+  }
+
+  /* --- Positioning --------------------------------------------------- */
+  function placePop(ref) {
+    var margin = 12;
+    var gap = 10;
+    var vw = document.documentElement.clientWidth;
+    var vh = window.innerHeight || document.documentElement.clientHeight;
+
+    // Let the card size to its content first (CSS caps the max width).
+    pop.style.left = '0px';
+    pop.style.top = '0px';
+    var pw = pop.offsetWidth;
+    var ph = pop.offsetHeight;
+
+    var r = ref.getBoundingClientRect();
+    var refCx = r.left + r.width / 2;
+
+    // Horizontal: centre on the marker, clamped to the viewport.
+    var left = Math.round(refCx - pw / 2);
+    left = Math.max(margin, Math.min(left, vw - pw - margin));
+
+    // Vertical: prefer above the marker; flip below if it would clip.
+    var placeBelow = r.top - ph - gap < margin;
+    var top = placeBelow ? r.bottom + gap : r.top - ph - gap;
+    top = Math.max(margin, Math.min(top, vh - ph - margin));
+
+    pop.classList.toggle('is-below', placeBelow);
+    // Point the little arrow at the marker (clamped within the card).
+    var arrowX = Math.max(14, Math.min(refCx - left, pw - 14));
+    pop.style.setProperty('--fn-arrow-x', arrowX + 'px');
+
+    pop.style.left = left + window.scrollX + 'px';
+    pop.style.top = top + window.scrollY + 'px';
+  }
+
+  /* --- Show / hide --------------------------------------------------- */
+  function show(ref) {
+    var html = noteHtmlFor(ref);
+    if (!html) return; // nothing to preview → leave the link alone
+    buildPop();
+    window.clearTimeout(hideTimer);
+
+    popBody.innerHTML = html;
+    popMore.setAttribute('href', ref.getAttribute('href'));
+    currentRef = ref;
+    ref.setAttribute('aria-describedby', popId);
+
+    placePop(ref);
+    pop.setAttribute('aria-hidden', 'false');
+    // Reflow so the entrance transition replays from the hidden state.
+    void pop.offsetWidth;
+    pop.classList.add('is-visible');
+  }
+
+  function hide() {
+    window.clearTimeout(showTimer);
+    window.clearTimeout(hideTimer);
+    if (!pop) return;
+    pop.classList.remove('is-visible');
+    pop.setAttribute('aria-hidden', 'true');
+    if (currentRef) {
+      currentRef.removeAttribute('aria-describedby');
+      currentRef = null;
+    }
+  }
+
+  function scheduleShow(ref) {
+    window.clearTimeout(showTimer);
+    showTimer = window.setTimeout(function () {
+      show(ref);
+    }, 120);
+  }
+  function scheduleHide() {
+    window.clearTimeout(hideTimer);
+    hideTimer = window.setTimeout(hide, 180);
+  }
+
+  /* --- Wiring -------------------------------------------------------- */
+  if (isTouch) {
+    // Tap to open (keeping the reader's place). A second tap on the same
+    // marker, or tapping the "go to note" link, follows through.
+    refs.forEach(function (ref) {
+      ref.addEventListener('click', function (e) {
+        if (currentRef === ref && pop && pop.classList.contains('is-visible')) {
+          // Second tap → let the native jump happen.
+          hide();
+          return;
+        }
+        e.preventDefault();
+        show(ref);
+      });
+    });
+    // Tap outside the card (and not on a marker) closes it.
+    document.addEventListener(
+      'click',
+      function (e) {
+        if (!pop || !pop.classList.contains('is-visible')) return;
+        if (pop.contains(e.target)) return;
+        if (e.target.closest && e.target.closest('a.footnote-ref')) return;
+        hide();
+      },
+      true
+    );
+    // Reposition / dismiss on scroll so the card never strands mid-page.
+    window.addEventListener(
+      'scroll',
+      function () {
+        if (pop && pop.classList.contains('is-visible')) hide();
+      },
+      { passive: true }
+    );
+  } else {
+    // Desktop: hover + keyboard focus.
+    refs.forEach(function (ref) {
+      ref.addEventListener('mouseenter', function () {
+        scheduleShow(ref);
+      });
+      ref.addEventListener('mouseleave', function () {
+        window.clearTimeout(showTimer);
+        scheduleHide();
+      });
+      ref.addEventListener('focus', function () {
+        show(ref);
+      });
+      ref.addEventListener('blur', function () {
+        scheduleHide();
+      });
+    });
+    window.addEventListener(
+      'scroll',
+      function () {
+        if (currentRef) placePop(currentRef);
+      },
+      { passive: true }
+    );
+  }
+
+  // Esc always closes; resizing re-anchors a live card.
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape' || e.keyCode === 27) hide();
+  });
+  window.addEventListener(
+    'resize',
+    function () {
+      if (currentRef && pop && pop.classList.contains('is-visible')) {
+        placePop(currentRef);
+      }
+    },
+    { passive: true }
+  );
+
+  // Expose the motion preference to CSS via a hook class on the popover
+  // host. (CSS also re-checks the media query — this is just belt-and-
+  // braces for engines that mis-handle the query at load.)
+  if (prefersReduced && pop) pop.classList.add('fn-popover--no-motion');
+})();

--- a/static/js/micro-interactions.js
+++ b/static/js/micro-interactions.js
@@ -28,6 +28,11 @@
     '.ai-tech-list-item',
     '.growth-list-item',
     '.reveal-item',
+    // Related-post cards at the foot of an article — fade/rise into the
+    // same cascade as everything else so the read unfolds all the way to
+    // the "continue reading" grid. Hidden state lives in
+    // micro-interactions.css; they stagger by their shared grid parent.
+    '.rpc',
     // Homepage day-page: the sections below the hero (latest posts,
     // category tiles, field notebooks, projects, repos) used to pop in
     // instantly. Reveal each section header and card as it scrolls into

--- a/static/js/toc-highlight.js
+++ b/static/js/toc-highlight.js
@@ -11,6 +11,22 @@
 
     if (!allTocLinks.length) return;
 
+    // Replay the deep-link "landing" pulse on the destination. We can't rely
+    // on :target here: this handler smooth-scrolls and updates the hash with
+    // history.replaceState(), which does not re-match :target, so the pulse in
+    // interaction-polish.css would never fire on a TOC click. Toggle a class
+    // that runs the same wash + accent-bar animation instead. Force a reflow
+    // between remove/add so rapid re-clicks on the same heading replay cleanly.
+    function flashTarget(el) {
+      el.classList.remove('anchor-target-flash');
+      void el.offsetWidth; // reflow → restart the keyframes
+      el.classList.add('anchor-target-flash');
+      window.clearTimeout(el.__flashTimer);
+      el.__flashTimer = window.setTimeout(function () {
+        el.classList.remove('anchor-target-flash');
+      }, 2100); // just past the 2s animation
+    }
+
     // Enable smooth scrolling for TOC links and hash sync
     allTocLinks.forEach(function (link) {
       link.addEventListener('click', function (e) {
@@ -22,6 +38,8 @@
         target.scrollIntoView({ behavior: 'smooth' });
         // Update URL hash without jumping
         history.replaceState(null, '', href);
+        // Highlight where the reader just landed (gated + neutralised in CSS).
+        flashTarget(target);
       });
     });
 


### PR DESCRIPTION
## Summary

This branch started as a fix for related-posts cover resolution and grew into a wider polish pass. Three independent threads landed here:

### 1. Full XML subscription stack (RSS / JSON Feed / OPML / news sitemap)
- Adds services.rss.limit = -1 so the home/section RSS feeds never silently truncate (root cause of the original feed-feels-incomplete complaint).
- Ships a custom layouts/_default/rss.xml with category (tags+categories), enclosure (cover image), media:content, dc:creator, atom:updated, and correct resolution of bundle-relative cover paths.
- New formats:
  - JSON Feed 1.1 at /feed.json and /<section>/feed.json
  - OPML 2.0 at /subscriptions.opml (one-click import of every channel)
  - Google News sitemap at /news-sitemap.xml (48-hour window)
- Image sitemap now emits image:title + image:caption and resolves bundle paths.
- robots.txt advertises the news sitemap.

Validation: hugo build clean, xmllint passes on all 7 XML outputs; ZH home RSS items 3 -> 97, JSON Feed home items 3 -> 97 (matches RSS).

### 2. Homepage subscribe area — surface the new feeds
- Subscribe meta row gets JSON + OPML chips next to the RSS pill.
- New "By channel" pill row: one rounded pill per section with a channel-coloured dot and an RSS format chip.
- Footer Connect column lists RSS, JSON Feed, OPML (all) as siblings.
- Styling matches the existing magazine/print language (mono labels, hairline borders, --accent-soft surface); light/dark/mobile all tuned.

### 3. Motion, dark-mode contrast, related-posts polish (earlier commits on this branch)
- fix(related-posts): resolve cover.image relative paths to working URLs (the original branch goal).
- feat(motion): scroll-reveal + press feedback on related-post cards, inline footnote previews, accent underline on card titles, replay landing pulse on TOC clicks.
- style(dark): AA-contrast lift for newsletter status, AI widget heading, profile AI icon, swipe hint, copy-code, TL;DR node; calmer inline-code chip; tamer related-posts cover glare.

## Test plan
- [ ] Visit /zh/index.xml and confirm 97 items with category, enclosure, dc:creator
- [ ] Visit /feed.json — valid JSON Feed 1.1, ~95 items
- [ ] Download /subscriptions.opml and import into a reader (e.g. NetNewsWire)
- [ ] Visit /news-sitemap.xml — recent posts only
- [ ] Inspect homepage subscribe section: RSS / JSON / OPML chips visible, 4 channel pills below, footer lists all three feed formats
- [ ] Toggle dark mode and resize to 390px — channel pills wrap; contrast holds
- [ ] Open a post: related-posts cover images load, hover reveal works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSON Feed, OPML, and news sitemap outputs.
  * Expanded the Subscribe area with per-channel feed links and download options.
  * Introduced inline footnote previews and improved table-of-contents highlight feedback.

* **Bug Fixes**
  * Improved dark-mode contrast for articles, code copy feedback, footnote popovers, and related content.
  * Fixed several image and cover display cases so titles, captions, and previews render more reliably.

* **Style**
  * Refined hover, focus, press, and scroll-reveal micro-interactions across cards and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->