### PR TITLE
[codex] polish interactions, dark contrast, and copy controls

### DIFF
--- a/assets/css/extended/zz-dark-reading.css
+++ b/assets/css/extended/zz-dark-reading.css
@@ -1080,3 +1080,87 @@ body.dark .rpc:hover .rpc__cover img,
 [data-theme="dark"] .rpc:hover .rpc__cover img {
   filter: brightness(1) contrast(1);
 }
+
+/* ── 32. "Projects" cyan accent UI in dark (AA repair) ────────────
+   The site uses a cyan "projects" brand colour, #0e7490 (cyan-700), for a
+   cluster of NON-prose UI: the home profile's title accent + terminal
+   prompt + "view more" ghost button + featured-post bold lead, the Archives
+   hero stat number and the per-year count badge, and the Posts hero count.
+   All seven rules paint #0e7490 and are NOT theme-gated, so the same dark cyan
+   is reused in dark mode — where it lands on the near-black paper (and, for
+   the featured-post lead, on its dark gradient card) (#121413 EN / #1c1917 ZH) at
+   just 3.45:1 (EN) / 3.27:1 (ZH), UNDER the WCAG-AA 4.5:1 text floor. So the
+   profile's accent, the archive/posts counters and the year badges — several
+   of the first numbers a reader's eye lands on — render as a dim cyan-on-dark
+   smudge.
+
+   This codebase ALREADY standardised the dark form of this exact cyan: the
+   projects badge and the "signal" icon were given color:#22d3ee (cyan-400)
+   for dark (custom.css: .dark .posts-badge--projects, .dark .signal-icon).
+   These six states were simply missed. Reuse #22d3ee so the cyan reads
+   consistently across every projects surface — it resolves to 10.24:1 (EN) /
+   9.68:1 (ZH), restoring comfortable AA and matching the established family
+   (the same move §22 made for the violet #7c3aed → #a78bfa). The faint chip /
+   border tints (rgba(14,116,144,…)) on the year badge and ghost button are
+   non-text and already read fine, so only the text colour is repaired.
+
+   !important is carried because two of the source rules (.profile_title__accent,
+   .profile_view_more) declare `color: …7490 !important`; an equal-importance
+   body.dark rule with higher specificity (0,2,0 vs 0,1,0) wins, and the flag
+   is harmless on the other four (none has a dark hover that recolours text).
+   Each selector is body.dark / [data-theme="dark"]-scoped and loads LAST in
+   the extended bundle, so it wins in dark and is never selected in light —
+   light mode keeps #0e7490, provably unchanged. */
+body.dark .profile_title__accent,
+body.dark .profile_terminal__prompt,
+body.dark .profile_view_more,
+body.dark .profile_post--featured strong,
+body.dark .archives-stat__number,
+body.dark .archives-year__count,
+body.dark .posts-hero__count,
+[data-theme="dark"] .profile_title__accent,
+[data-theme="dark"] .profile_terminal__prompt,
+[data-theme="dark"] .profile_view_more,
+[data-theme="dark"] .profile_post--featured strong,
+[data-theme="dark"] .archives-stat__number,
+[data-theme="dark"] .archives-year__count,
+[data-theme="dark"] .posts-hero__count {
+  color: #22d3ee !important;
+}
+
+/* ── 33. Section-list tag text in dark (AA repair) ────────────────
+   The "AI 技术" and "成长 / Growth" section LIST rows label their tags with a
+   flat grey — .ai-tech-list-tags #6b7280 and .growth-list-tags #78716c — and
+   neither rule is theme-gated, so the same grey is reused in dark. On the
+   near-black paper that lands at 3.83:1 / 3.86:1 respectively — UNDER the AA
+   4.5:1 floor for this small (≈0.8rem) tag text, so the tag line reads as a
+   barely-there grey smudge under each list title. Repaint with the design's
+   muted-ink token (the same family already used for the meta line §21, list
+   markers §18, footnotes §7 and struck text §19), which resolves per language
+   to #b4bcb2 (EN, 9.49:1) / #a8a29e (ZH, 6.93:1) — comfortably AA and still
+   clearly recessed below the list title, so the hierarchy is unchanged. The
+   sibling CARD tags already inherit an AA-safe colour, so only the list-row
+   tags needed this. body.dark-scoped, loaded last — light mode keeps the
+   grey, provably unchanged. */
+body.dark .ai-tech-list-tags,
+body.dark .growth-list-tags,
+[data-theme="dark"] .ai-tech-list-tags,
+[data-theme="dark"] .growth-list-tags {
+  color: var(--color-ink-muted, #b4bcb2);
+}
+
+/* ── 34. Archives "draft" badge in dark (AA repair) ──────────────
+   The Archives list flags unpublished entries with a draft badge:
+   .archives-post__draft paints amber #b45309 on a faint amber chip
+   (background rgba(234,179,8,0.15)), un-gated. In dark the chip is a faint
+   amber wash over the near-black paper and the #b45309 text lands at just
+   3.68:1 (EN) / 3.49:1 (ZH) — under the AA floor for this small uppercase
+   label. Lift the text to amber-400 #fbbf24 — the exact tint §27 already
+   uses for the dark "warning" state — so the badge keeps its amber semantic
+   while clearing AA at 11.08:1 (EN) / 10.48:1 (ZH) over the paper, and reads
+   crisply against its own faint chip. body.dark-scoped, loaded last — light
+   mode keeps #b45309, provably unchanged. */
+body.dark .archives-post__draft,
+[data-theme="dark"] .archives-post__draft {
+  color: #fbbf24;
+}

--- a/assets/css/extended/zzz-interaction-detail-v4.css
+++ b/assets/css/extended/zzz-interaction-detail-v4.css
@@ -1,0 +1,114 @@
+/* ============================================================
+   zzz-interaction-detail-v4.css — detail motion & polish (v4)
+   ------------------------------------------------------------
+   Two small, verified-absent touches that extend the existing
+   micro-interaction family without duplicating it — one for the
+   brief's 点击 (tap/click) and one for 下滑 (scroll):
+
+     1. Search palette input — focus underline bloom. The command
+        palette's search field sits on a flat 1px rule that only
+        nudged the icon colour on focus (theme header.css). Add an
+        accent underline that grows out from the centre the instant
+        the field is focused (tap on mobile, click / ⌘K on desktop),
+        so the field "wakes up" the way the in-prose link underline
+        does on hover. Language-aware EN/ZH accent.
+
+     2. Article blockquotes — accent bar draw-in on scroll. A pulled
+        quote already fades up as it enters view (the prose reveal in
+        micro-interactions). Layer a quick vertical "draw" of its left
+        accent bar on top, so the quote feels authored into place as
+        you scroll down a long read rather than the bar just being
+        there. Robust by construction: the real border is only handed
+        over to the animated bar once the enhancement is active, so
+        no-JS / reduced-motion readers always see a solid accent bar.
+
+   Everything here is purely additive feedback — never required for
+   content to be read. The scroll touch is gated behind .motion-reveal
+   (added to <html> only when the visitor has NOT requested reduced
+   motion) and the whole file is neutralised under prefers-reduced-
+   motion at the bottom. Loads last in the extended bundle (zzz-
+   prefix) so its rules win cleanly.
+   ============================================================ */
+
+/* ---------- 1. Search palette: focus underline bloom (tap / click) ----------
+   The wrap is already position:relative (theme header.css), so the
+   underline can ride its bottom edge. It grows from the centre out and
+   eases back on blur — a quiet "the field is live" cue felt on a phone
+   tap and a desktop click / ⌘K alike. The existing 1px rule stays as
+   the resting track underneath. */
+.search-palette__input-wrap::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  right: auto;
+  bottom: -1px; /* sit exactly over the wrap's 1px bottom rule */
+  height: 2px;
+  width: 0;
+  transform: translateX(-50%);
+  background: var(--color-accent, #7a5c40);
+  border-radius: 2px;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    width 0.28s cubic-bezier(0.22, 0.61, 0.36, 1),
+    opacity 0.28s ease;
+}
+.search-palette__input-wrap:focus-within::after {
+  width: 100%;
+  opacity: 1;
+}
+/* ZH leans on the deep-red accent identity; EN on sky/sage. The var()
+   resolves per-language where --color-accent is set, but pin explicit
+   fallbacks so the bloom is always on-brand. */
+html:lang(zh) .search-palette__input-wrap::after {
+  background: var(--color-accent, #862122);
+}
+
+/* ---------- 2. Blockquote: accent bar draw-in on scroll reveal (下滑) ----------
+   `.post-content > blockquote` is tagged `.reveal-block` by
+   micro-interactions.js and fades up on entry. Only when that
+   enhancement is live (html.motion-reveal) do we hand the left accent
+   over to an animated bar: hide the real border and draw a fresh one
+   downward from the top as the quote settles in. Because the prose
+   reveal always ends in `.is-revealed` (immediate for first-screen
+   quotes, a 2.5s safety net otherwise, and forced under reduced
+   motion), the bar is guaranteed to finish fully drawn. */
+html.motion-reveal .post-content > blockquote.reveal-block {
+  position: relative;
+  /* Hand the accent over to the animated bar below. */
+  border-left-color: transparent;
+}
+html.motion-reveal .post-content > blockquote.reveal-block::before {
+  content: "";
+  position: absolute;
+  left: -2px; /* overlay the 2px border-left track */
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--color-accent);
+  transform: scaleY(0);
+  transform-origin: top center;
+  transition: transform 0.5s cubic-bezier(0.22, 0.61, 0.36, 1);
+  /* follow the quote's own fade-up by a hair */
+  transition-delay: 0.08s;
+  pointer-events: none;
+}
+html.motion-reveal .post-content > blockquote.reveal-block.is-revealed::before {
+  transform: scaleY(1);
+}
+
+/* ============================================================
+   Reduced motion: drop the bloom transition and hand the blockquote
+   accent straight back to a solid, fully-drawn bar — no movement.
+   ============================================================ */
+@media (prefers-reduced-motion: reduce) {
+  .search-palette__input-wrap::after {
+    transition: none !important;
+  }
+  html.motion-reveal .post-content > blockquote.reveal-block {
+    border-left-color: var(--color-accent) !important;
+  }
+  html.motion-reveal .post-content > blockquote.reveal-block::before {
+    display: none !important;
+  }
+}

--- a/assets/css/extended/zzz-press-feedback.css
+++ b/assets/css/extended/zzz-press-feedback.css
@@ -129,3 +129,72 @@
     transition: none !important;
   }
 }
+
+/* ============================================================
+   Pagination & tag-link controls — bring them into the family
+   ------------------------------------------------------------
+   The article prev/next pair (.paginav a) already settles on
+   :active (micro-interactions.css), and whole-card links press
+   above. But three other interactive controls only changed on
+   HOVER and gave no tap response on a phone:
+
+   • Section list pagination — .eit-page-btn / .eig-page-btn
+     (AI-tech & growth "← prev / next →") lift on hover
+     (editorial-sections.css) but had no press beat.
+   • The PaperMod-style .pagination a buttons (technology section
+     + default list) lift on hover (custom.css) with the same gap.
+   • The homepage profile tag links (.profile_nav_tag) recolour on
+     hover (custom.css) but, as real <a> links, never confirmed a
+     tap.
+
+   Add the same press cue used for the rest of the family: fine
+   pointers settle down out of their hover lift; touch gets a
+   slightly deeper scale so the tap reads as confirmed before the
+   page changes. Loads last (zzz-) so :active wins at equal
+   specificity, and the default grey tap-flash is replaced by our
+   own cue. Fully neutralised under reduced motion below.
+   ============================================================ */
+.eit-page-btn,
+.eig-page-btn,
+.pagination a,
+.profile_nav_tag {
+  -webkit-tap-highlight-color: transparent;
+}
+
+/* Fine pointers (mouse / trackpad): settle down from the hover lift. */
+@media (hover: hover) and (pointer: fine) {
+  .eit-page-btn:active,
+  .eig-page-btn:active,
+  .pagination a:active {
+    transform: translateY(0) scale(0.97);
+    transition: transform 0.1s ease;
+  }
+  .profile_nav_tag:active {
+    transform: scale(0.95);
+    transition: transform 0.1s ease;
+  }
+}
+
+/* Touch / coarse pointers: a slightly deeper, springy press. */
+@media (hover: none) and (pointer: coarse) {
+  .eit-page-btn:active,
+  .eig-page-btn:active,
+  .pagination a:active {
+    transform: scale(0.96);
+    transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+  .profile_nav_tag:active {
+    transform: scale(0.93);
+    transition: transform 0.12s cubic-bezier(0.34, 1.56, 0.64, 1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eit-page-btn:active,
+  .eig-page-btn:active,
+  .pagination a:active,
+  .profile_nav_tag:active {
+    transform: none !important;
+    transition: none !important;
+  }
+}

--- a/layouts/partials/extend_foot.html
+++ b/layouts/partials/extend_foot.html
@@ -1,21 +1,73 @@
+{{- /* Fallback copy-code button.
+       The theme (footer.html) already adds a themed `.copy-code` control to
+       code blocks on single article pages. This is a safety net for code that
+       shows up on other page kinds (lists / archives / search) where that
+       scoped script never runs.
+
+       Two fixes over the old version:
+         1. No more double buttons. The theme places its control INSIDE the
+            <pre> for plain blocks but on the `.highlight` WRAPPER for
+            syntax-highlighted ones — so the old `pre.querySelector('button')`
+            guard missed it and every highlighted block ended up with two
+            stacked copy buttons. We now also check the `.highlight` wrapper.
+         2. Reuse the `.copy-code` class instead of a hard-coded dark button,
+            so the fallback inherits the same theme styling, hover / touch
+            reveal and "copied!" pop as the primary control (the old
+            background:#444 button ignored light/dark theme entirely). */ -}}
 <script>
-document.addEventListener('DOMContentLoaded', function() {
-  document.querySelectorAll('pre code').forEach(function(codeBlock) {
+document.addEventListener('DOMContentLoaded', function () {
+  var isZh = (document.documentElement.lang || '').toLowerCase().indexOf('zh') === 0;
+  var LABEL_COPY = isZh ? '复制' : 'copy';
+  var LABEL_DONE = isZh ? '已复制!' : 'copied!';
+
+  document.querySelectorAll('pre > code').forEach(function (codeBlock) {
     var pre = codeBlock.parentElement;
-    // Skip if theme already added a copy button
+    var wrap = pre.parentElement;
+
+    // Already has a copy control? Skip — never stack a second button.
     if (pre.querySelector('button')) return;
+    if (wrap && wrap.classList.contains('highlight') && wrap.querySelector('button')) return;
+
     var button = document.createElement('button');
-    button.className = 'copy-code-btn';
-    button.textContent = 'Copy';
-    button.addEventListener('click', function() {
-      navigator.clipboard.writeText(codeBlock.innerText).then(function() {
-        button.textContent = 'Copied!';
-        setTimeout(function() { button.textContent = 'Copy'; }, 2000);
-      });
+    button.type = 'button';
+    button.className = 'copy-code';
+    button.textContent = LABEL_COPY;
+
+    button.addEventListener('click', function () {
+      var text = codeBlock.textContent;
+      var done = function () {
+        button.textContent = LABEL_DONE;
+        button.classList.add('is-copied');
+        window.clearTimeout(button.__copiedTimer);
+        button.__copiedTimer = window.setTimeout(function () {
+          button.textContent = LABEL_COPY;
+          button.classList.remove('is-copied');
+        }, 2000);
+      };
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(text).then(done).catch(function () {});
+      } else {
+        // Legacy fallback for browsers without the async clipboard API.
+        try {
+          var range = document.createRange();
+          range.selectNodeContents(codeBlock);
+          var sel = window.getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+          document.execCommand('copy');
+          sel.removeAllRanges();
+          done();
+        } catch (e) {}
+      }
     });
-    pre.style.position = 'relative';
-    button.style.cssText = 'position:absolute;top:8px;right:8px;padding:2px 8px;font-size:12px;cursor:pointer;background:#444;color:#fff;border:none;border-radius:4px;opacity:0.8;';
-    pre.appendChild(button);
+
+    // Mirror the theme's placement so the `.copy-code` positioning rules
+    // (which target both `.highlight .copy-code` and `pre .copy-code`) apply.
+    if (wrap && wrap.classList.contains('highlight')) {
+      wrap.appendChild(button);
+    } else {
+      pre.appendChild(button);
+    }
   });
 });
 </script>


### PR DESCRIPTION
## What changed

- add focus/hover motion details for search controls, blockquotes, pagination, and profile tag links
- raise dark-theme contrast for project cyan accents, section-list tags, and draft badges to AA targets
- make the fallback code-copy control reuse the theme styling and avoid duplicate buttons on highlighted blocks
- localize fallback copy labels for Chinese and English pages and retain a legacy clipboard fallback

## Why

These changes make interaction feedback more consistent, improve dark-mode readability, and fix duplicate or visually inconsistent copy controls on page types where the theme-scoped script does not run.

## Impact

Readers get clearer keyboard and pointer feedback, more legible dark-mode accents, and one consistent copy button per code block.

## Validation

- `git diff --check origin/main...HEAD`
- `hugo --minify` (EN: 422 pages, ZH: 490 pages)

## Notes

Root-level `_*.mjs` audit and screenshot helpers remain untracked and are intentionally excluded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smoother search, blockquote, and button interactions for a more polished browsing experience.
  * Improved copy-to-clipboard behavior and label handling for content blocks, including language-aware text.

* **Bug Fixes**
  * Improved dark-mode contrast for several UI elements, including counters, tags, and draft labels.
  * Enhanced reduced-motion support so visual effects stay comfortable for motion-sensitive users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->