### PR TITLE
feat(seo): og:site_name, og:locale, rich-result robots & JSON-LD language hints

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
 {{- if or (eq .Kind "404") .Params.robotsNoIndex }}
 <meta name="robots" content="noindex, nofollow">
 {{- else if hugo.IsProduction | or (eq site.Params.env "production") }}
-<meta name="robots" content="index, follow">
+<meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1, max-video-preview:-1">
 {{- else }}
 <meta name="robots" content="noindex, nofollow">
 {{- end }}

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -33,6 +33,14 @@
 {{- /* Open Graph / Facebook */ -}}
 {{- $ogType := cond (or .IsHome (eq .Kind "taxonomy") (eq .Kind "term") (eq .Kind "section")) "website" "article" -}}
 <meta property="og:type" content="{{ $ogType }}" />
+<meta property="og:site_name" content="{{ site.Title }}" />
+{{- $ogLocale := cond (eq .Language.Lang "zh") "zh_CN" "en_US" -}}
+<meta property="og:locale" content="{{ $ogLocale }}" />
+{{- range .AllTranslations -}}
+{{- if ne .Language.Lang $.Language.Lang -}}
+<meta property="og:locale:alternate" content="{{ cond (eq .Language.Lang "zh") "zh_CN" "en_US" }}" />
+{{- end -}}
+{{- end -}}
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:title" content="{{ $title | plainify }}" />
 <meta property="og:description" content="{{ $description | plainify }}" />
@@ -70,7 +78,9 @@
 <meta name="twitter:title" content="{{ $title | plainify }}" />
 <meta name="twitter:description" content="{{ $description | plainify }}" />
 <meta name="twitter:image" content="{{ $ogImage | absURL }}" />
+<meta name="twitter:image:alt" content="{{ with .Params.cover.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" />
 {{- with site.Params.social.twitter -}}
+<meta name="twitter:site" content="@{{ . }}" />
 <meta name="twitter:creator" content="@{{ . }}" />
 {{- end -}}
 

--- a/layouts/partials/seo/structured-data.html
+++ b/layouts/partials/seo/structured-data.html
@@ -36,8 +36,10 @@
   {{- end -}}
   "author": {
     "@type": "Person",
-    "name": {{ $postAuthor | plainify | jsonify }}
+    "name": {{ $postAuthor | plainify | jsonify }},
+    "url": {{ site.BaseURL }}
   },
+  "inLanguage": "{{ if eq .Language.Lang "zh" }}zh-CN{{ else }}en-US{{ end }}",
   "publisher": {
     "@type": "Organization",
     "name": {{ $siteName }},


### PR DESCRIPTION
## Summary

Hourly SEO analysis pass. The site already has a mature SEO setup (canonical, sitemap + news sitemap, robots.txt, hreflang, BlogPosting/WebSite/Person/BreadcrumbList JSON-LD, per-section OG images). While auditing the **actually rendered** `<head>`, I found that `layouts/partials/templates/opengraph.html` and `twitter_cards.html` are **dead code** — nothing includes them. The real head is built by `layouts/partials/seo.html`, which was missing several standard signals. This PR closes those gaps.

## Changes

- **robots meta** (`head.html`): add `max-image-preview:large, max-snippet:-1, max-video-preview:-1` — opts posts into large image thumbnails in Google Search & Google Discover.
- **Open Graph** (`seo.html`): add `og:site_name`; add `og:locale` (zh_CN / en_US from page language) and reciprocal `og:locale:alternate` derived from translations, so Facebook/LinkedIn/WeChat unfurl the correct locale.
- **Twitter** (`seo.html`): add `twitter:site` and `twitter:image:alt` alongside the existing `twitter:creator`.
- **BlogPosting JSON-LD** (`structured-data.html`): add `inLanguage` and `author.url`.

## Verification

- `hugo --gc --minify -b https://nsddd.top` (extended v0.140.2) builds cleanly — 462 EN + 526 ZH pages, no errors.
- Confirmed new tags render on both an EN and a ZH post; `og:locale` / `og:locale:alternate` flip correctly per language.
- Validated every `application/ld+json` block on the sample pages still parses as valid JSON (BlogPosting, WebSite, Person, BreadcrumbList).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PwZe2HFk5RMYATmJCceZWG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved page SEO and social sharing metadata, including richer Open Graph, Twitter, and structured data details for better previews across platforms.
  * Enhanced search engine metadata for production pages to allow more complete content previews in results.

* **Bug Fixes**
  * Added language and locale details to help multilingual pages display more accurately in search and social sharing contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->