### PR TITLE
feat(social): add polished WeChat contact card (QR + ID)

### DIFF
--- a/assets/css/extended/zzz-wechat-contact.css
+++ b/assets/css/extended/zzz-wechat-contact.css
@@ -1,0 +1,421 @@
+/* ═══════════════════════════════════════════════════════════════════════
+   WeChat contact card
+   A polished "Add me on WeChat" dialog + the social-row trigger button.
+   Self-contained, theme-aware, motion-safe. Loads site-wide.
+   ═══════════════════════════════════════════════════════════════════════ */
+
+:root {
+  --wx-green: #07c160;
+  --wx-green-strong: #06a850;
+}
+
+/* ── Trigger button — sits inside .social-icons alongside the <a> chips ─── */
+.social-icons__wechat {
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  line-height: 0;
+  -webkit-tap-highlight-color: transparent;
+}
+.social-icons__wechat svg {
+  height: 26px;
+  width: 26px;
+  transition: color 0.18s ease;
+}
+/* The preceding <a> is :last-of-type so core drops its trailing margin —
+   restore the gap on the button's leading edge instead. */
+.social-icons__wechat { margin-inline-start: 12px; }
+@media (hover: hover) and (pointer: fine) {
+  .social-icons__wechat:hover { color: var(--wx-green); }
+}
+.social-icons__wechat:focus-visible {
+  outline: 2px solid var(--wx-green);
+  outline-offset: 3px;
+  border-radius: 8px;
+}
+
+/* Profile homepage renders the row as 42px circular chips — match it. */
+.profile .social-icons__wechat {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  margin-inline-start: 0; /* profile anchors already carry margin-right */
+  margin-right: 10px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--theme) 80%, transparent);
+  transition: transform 0.18s ease, border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
+}
+.profile .social-icons__wechat svg { height: 22px; width: 22px; }
+@media (hover: hover) and (pointer: fine) {
+  .profile .social-icons__wechat:hover {
+    color: var(--wx-green);
+    border-color: color-mix(in srgb, var(--wx-green) 45%, var(--border));
+    background: color-mix(in srgb, var(--wx-green) 10%, var(--theme));
+    transform: translateY(-2px);
+  }
+}
+.profile .social-icons__wechat:active { transform: scale(0.92); }
+
+/* Homepage hero social row (homepage-daypage) — button variant that inherits
+   the .hp-social-icon chip and only resets native button chrome. */
+.hp-social-icon--wechat {
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.hp-social-icon--wechat:hover {
+  color: var(--wx-green);
+  border-color: color-mix(in srgb, var(--wx-green) 45%, var(--border-subtle));
+  background: color-mix(in srgb, var(--wx-green) 10%, var(--surface-white));
+}
+.hp-social-icon--wechat:active { transform: scale(0.92); }
+.hp-social-icon--wechat:focus-visible { outline: 2px solid var(--wx-green); outline-offset: 2px; }
+
+/* Homepage footer "Connect" list — button that reads as a text link. */
+.hp-footer-wechat {
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-body);
+  font-size: 13px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color 160ms;
+}
+.hp-footer-wechat:hover { color: var(--wx-green); }
+.hp-footer-wechat:focus-visible {
+  outline: 2px solid var(--wx-green);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* ── Backdrop ─────────────────────────────────────────────────────────── */
+.wxc-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 3000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  background: color-mix(in srgb, #0a0f14 62%, transparent);
+  -webkit-backdrop-filter: blur(6px) saturate(120%);
+  backdrop-filter: blur(6px) saturate(120%);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.28s ease, visibility 0s linear 0.28s;
+}
+.wxc-backdrop.is-open {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 0.28s ease;
+}
+
+/* ── Card ─────────────────────────────────────────────────────────────── */
+.wxc-card {
+  position: relative;
+  width: 100%;
+  max-width: 348px;
+  padding: 30px 26px 24px;
+  border-radius: 22px;
+  background: var(--entry);
+  border: 1px solid var(--border);
+  box-shadow:
+    0 24px 60px -20px rgba(0, 0, 0, 0.5),
+    0 2px 10px rgba(0, 0, 0, 0.12);
+  text-align: center;
+  transform: translateY(14px) scale(0.965);
+  opacity: 0;
+  transition: transform 0.34s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.28s ease;
+}
+.wxc-backdrop.is-open .wxc-card {
+  transform: translateY(0) scale(1);
+  opacity: 1;
+}
+/* soft WeChat-green aura along the top edge */
+.wxc-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 4px;
+  border-radius: 22px 22px 0 0;
+  background: linear-gradient(90deg, transparent, var(--wx-green), transparent);
+  opacity: 0.85;
+}
+
+.wxc-close {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 50%;
+  background: color-mix(in srgb, var(--primary) 6%, transparent);
+  color: var(--secondary);
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 0.18s ease, color 0.18s ease, transform 0.18s ease;
+}
+.wxc-close:hover {
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  color: var(--primary);
+  transform: rotate(90deg);
+}
+.wxc-close:focus-visible { outline: 2px solid var(--wx-green); outline-offset: 2px; }
+
+/* Header */
+.wxc-head {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 11px;
+  margin-bottom: 10px;
+}
+.wxc-logo {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 13px;
+  color: #fff;
+  background: linear-gradient(135deg, var(--wx-green), var(--wx-green-strong));
+  box-shadow: 0 6px 16px -6px color-mix(in srgb, var(--wx-green) 75%, transparent);
+  flex: none;
+}
+.wxc-logo svg { width: 25px; height: 25px; }
+.wxc-headtext { text-align: left; line-height: 1.15; }
+.wxc-title {
+  margin: 0;
+  font-size: 1.16rem;
+  font-weight: 700;
+  color: var(--primary);
+  letter-spacing: 0.01em;
+}
+.wxc-title-sub {
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--secondary);
+  opacity: 0.75;
+}
+.wxc-lead {
+  margin: 0 auto 18px;
+  max-width: 30ch;
+  font-size: 0.845rem;
+  line-height: 1.55;
+  color: var(--secondary);
+}
+
+/* ── QR ───────────────────────────────────────────────────────────────── */
+.wxc-qr {
+  display: inline-block;
+  text-decoration: none;
+  outline: none;
+}
+.wxc-qr-frame {
+  position: relative;
+  display: block;
+  width: 220px;
+  max-width: 68vw;
+  aspect-ratio: 1 / 1;
+  margin: 0 auto;
+  padding: 12px;
+  border-radius: 18px;
+  background: #fff;
+  border: 1px solid color-mix(in srgb, var(--wx-green) 22%, var(--border));
+  box-shadow: 0 10px 30px -14px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+.wxc-qr-img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
+  border-radius: 8px;
+  opacity: 0;
+  transform: scale(0.98);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+.wxc-qr-frame.is-loaded .wxc-qr-img { opacity: 1; transform: scale(1); }
+/* skeleton shimmer while the QR loads */
+.wxc-qr-frame:not(.is-loaded)::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 8px;
+  background: linear-gradient(100deg,
+    #eef1f4 30%, #f6f8fa 50%, #eef1f4 70%);
+  background-size: 200% 100%;
+  animation: wxc-shimmer 1.15s ease-in-out infinite;
+}
+@keyframes wxc-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+/* scanning laser sweep — the "it's alive" quality touch */
+.wxc-scanline {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  top: 12px;
+  height: 34px;
+  border-radius: 8px;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(
+    to bottom,
+    color-mix(in srgb, var(--wx-green) 0%, transparent),
+    color-mix(in srgb, var(--wx-green) 32%, transparent)
+  );
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--wx-green) 70%, transparent);
+}
+.wxc-qr-frame.is-loaded .wxc-scanline {
+  opacity: 1;
+  animation: wxc-scan 2.6s cubic-bezier(0.6, 0, 0.4, 1) infinite;
+}
+@keyframes wxc-scan {
+  0%   { transform: translateY(0); opacity: 0; }
+  12%  { opacity: 1; }
+  88%  { opacity: 1; }
+  100% { transform: translateY(158px); opacity: 0; }
+}
+@media (hover: hover) and (pointer: fine) {
+  .wxc-qr:hover .wxc-qr-frame {
+    border-color: color-mix(in srgb, var(--wx-green) 55%, var(--border));
+    box-shadow: 0 14px 34px -14px color-mix(in srgb, var(--wx-green) 45%, rgba(0,0,0,0.4));
+  }
+}
+
+.wxc-scanhint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  margin: 14px 0 16px;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--secondary);
+}
+.wxc-scanhint-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--wx-green);
+  box-shadow: 0 0 0 0 color-mix(in srgb, var(--wx-green) 60%, transparent);
+  animation: wxc-pulse 1.9s ease-out infinite;
+}
+@keyframes wxc-pulse {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--wx-green) 55%, transparent); }
+  70%  { box-shadow: 0 0 0 7px color-mix(in srgb, var(--wx-green) 0%, transparent); }
+  100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--wx-green) 0%, transparent); }
+}
+
+/* ── WeChat ID row ────────────────────────────────────────────────────── */
+.wxc-id {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 7px 7px 12px;
+  border-radius: 13px;
+  background: color-mix(in srgb, var(--primary) 4%, transparent);
+  border: 1px solid var(--border);
+}
+.wxc-id-label {
+  flex: none;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--secondary);
+  white-space: nowrap;
+}
+.wxc-id-value {
+  flex: 1 1 auto;
+  min-width: 0;
+  text-align: left;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--primary);
+  letter-spacing: 0.01em;
+  background: none;
+  padding: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wxc-copy {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  flex: none;
+  padding: 7px 11px;
+  border: none;
+  border-radius: 9px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, var(--wx-green), var(--wx-green-strong));
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, filter 0.16s ease;
+  box-shadow: 0 4px 12px -5px color-mix(in srgb, var(--wx-green) 70%, transparent);
+}
+.wxc-copy:hover { filter: brightness(1.06); transform: translateY(-1px); }
+.wxc-copy:active { transform: translateY(0) scale(0.97); }
+.wxc-copy:focus-visible { outline: 2px solid var(--wx-green); outline-offset: 2px; }
+.wxc-copy.is-done {
+  background: linear-gradient(135deg, #10b981, #059669);
+}
+.wxc-copy-ico { flex: none; }
+
+/* ── Dark theme touch-ups ─────────────────────────────────────────────── */
+.dark .wxc-backdrop { background: color-mix(in srgb, #000 72%, transparent); }
+.dark .wxc-card {
+  box-shadow:
+    0 26px 70px -22px rgba(0, 0, 0, 0.8),
+    0 0 0 1px color-mix(in srgb, var(--wx-green) 10%, transparent);
+}
+/* QR frame stays white in dark mode (scannability) — shimmer already light. */
+
+/* ── Responsive ───────────────────────────────────────────────────────── */
+@media (max-width: 420px) {
+  .wxc-card { padding: 26px 18px 20px; border-radius: 18px; }
+  .wxc-id { flex-wrap: wrap; }
+  .wxc-copy { width: 100%; justify-content: center; margin-top: 2px; }
+}
+
+/* ── Motion / accessibility ───────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .wxc-backdrop,
+  .wxc-card { transition: opacity 0.2s ease; }
+  .wxc-card { transform: none; }
+  .wxc-scanline,
+  .wxc-scanhint-dot,
+  .wxc-qr-frame:not(.is-loaded)::before { animation: none; }
+  .wxc-scanline { opacity: 0; }
+  .wxc-close:hover { transform: none; }
+}

--- a/config.yml
+++ b/config.yml
@@ -102,6 +102,10 @@ params:
     - name: xhs
       title: 小红书
       url: https://www.xiaohongshu.com/user/profile/62a33af9000000001b025dd3
+    - name: wechat
+      title: 微信 / WeChat
+      wechatID: nsddd_top
+      qr: /wechat.jpg
   social:
     twitter: cubxxw
   ShareButtons: ["linkedin", "twitter","bilibili","zhihu","email","facebook", "reddit", "telegram", "whatsapp", "ycombinator", "weibo", "xiaohongshu"] # To customize which share buttons to be enabled on page

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -28,3 +28,4 @@
 <script src="{{ "/js/footnote-preview.js" | relURL }}" defer></script>
 {{- end }}
 {{ partial "search-palette.html" . }}
+{{ partial "wechat-contact.html" . }}

--- a/layouts/partials/homepage-daypage.html
+++ b/layouts/partials/homepage-daypage.html
@@ -64,9 +64,30 @@
         {{- if site.Params.socialIcons }}
         <div class="hp-hero-socials">
           {{- range site.Params.socialIcons }}
+          {{- if eq .name "wechat" }}
+          {{- $qrSrc := .qr | relURL -}}
+          {{- with resources.Get "wechat.jpg" -}}
+            {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) -}}
+            {{- if and hugo.IsExtended $prod -}}
+              {{- $qrSrc = (.Resize "440x webp q88").RelPermalink -}}
+            {{- else -}}
+              {{- $qrSrc = (.Resize "440x q88").RelPermalink -}}
+            {{- end -}}
+          {{- end -}}
+          <button type="button" class="hp-social-icon hp-social-icon--wechat"
+            title="{{ .title | default "微信 / WeChat" }}"
+            aria-label="{{ .title | default "微信 / WeChat" }}"
+            aria-haspopup="dialog"
+            data-wechat-id="{{ .wechatID }}"
+            data-wechat-qr="{{ $qrSrc }}"
+            onclick="openWechatContact(this)">
+            {{ partial "svg.html" . }}
+          </button>
+          {{- else }}
           <a class="hp-social-icon" href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer" title="{{ .name | title }}">
             {{ partial "svg.html" . }}
           </a>
+          {{- end }}
           {{- end }}
         </div>
         {{- end }}
@@ -420,7 +441,22 @@
         <h5>{{ if $isZh }}联系{{ else }}Connect{{ end }}</h5>
         <ul>
           {{- range site.Params.socialIcons }}
+          {{- if eq .name "wechat" }}
+          {{- $qrSrc := .qr | relURL -}}
+          {{- with resources.Get "wechat.jpg" -}}
+            {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) -}}
+            {{- if and hugo.IsExtended $prod -}}
+              {{- $qrSrc = (.Resize "440x webp q88").RelPermalink -}}
+            {{- else -}}
+              {{- $qrSrc = (.Resize "440x q88").RelPermalink -}}
+            {{- end -}}
+          {{- end -}}
+          <li><button type="button" class="hp-footer-wechat" aria-haspopup="dialog"
+            data-wechat-id="{{ .wechatID }}" data-wechat-qr="{{ $qrSrc }}"
+            onclick="openWechatContact(this)">{{ .title | default (.name | title) }}</button></li>
+          {{- else }}
           <li><a href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer">{{ .title | default (.name | title) }}</a></li>
+          {{- end }}
           {{- end }}
           <li><a href="{{ "/index.xml" | relLangURL }}">RSS</a></li>
           {{- with (site.GetPage "/").OutputFormats.Get "JSONFeed" }}

--- a/layouts/partials/social_icons.html
+++ b/layouts/partials/social_icons.html
@@ -1,9 +1,35 @@
 <div class="social-icons">
     {{- range . }}
+    {{- if eq .name "wechat" }}
+    {{- /* WeChat has no clickable profile URL — render a button that opens an
+           on-site contact card (QR + WeChat ID) instead of a dead link.
+           The QR is served resized/optimised via Hugo Pipes when available,
+           falling back to the raw static asset. */ -}}
+    {{- $qrSrc := .qr | relURL -}}
+    {{- with resources.Get "wechat.jpg" -}}
+        {{- $prod := (hugo.IsProduction | or (eq site.Params.env "production")) -}}
+        {{- if and hugo.IsExtended $prod -}}
+            {{- $qrSrc = (.Resize "440x webp q88").RelPermalink -}}
+        {{- else -}}
+            {{- $qrSrc = (.Resize "440x q88").RelPermalink -}}
+        {{- end -}}
+    {{- end -}}
+    <button type="button"
+       class="social-icons__wechat"
+       title="{{ .title | default "微信 / WeChat" }}"
+       aria-label="{{ .title | default "微信 / WeChat" }}"
+       aria-haspopup="dialog"
+       data-wechat-id="{{ .wechatID }}"
+       data-wechat-qr="{{ $qrSrc }}"
+       onclick="openWechatContact(this)">
+        {{ partial "svg.html" . }}
+    </button>
+    {{- else }}
     <a href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer me"
        title="{{ (.title | default .name) | title }}"
        aria-label="{{ (.title | default .name) | title }}">
         {{ partial "svg.html" . }}
     </a>
+    {{- end }}
     {{- end }}
 </div>

--- a/layouts/partials/wechat-contact.html
+++ b/layouts/partials/wechat-contact.html
@@ -1,0 +1,144 @@
+{{- /* ── WeChat contact card ──────────────────────────────────────────────
+       A lightweight, on-site "Add me on WeChat" dialog: personal QR code +
+       copyable WeChat ID. Built lazily on first open, works on any page that
+       renders the wechat social icon. No third-party requests. */ -}}
+{{- $zh := eq site.Language.Lang "zh" -}}
+<script>
+(function () {
+  "use strict";
+
+  // Localised copy. jsonify + safeJS => one valid, correctly-escaped JS string
+  // literal per entry (no double-encoding, no HTML entities inside <script>).
+  var T = {
+    title:      {{ cond $zh "加我的微信" "Add me on WeChat" | jsonify | safeJS }},
+    titleSub:   {{ cond $zh "Add me on WeChat" "加我的微信" | jsonify | safeJS }},
+    lead:       {{ cond $zh "扫一扫二维码，或搜索微信号加我为好友，一起聊 AI、开源与远程生活。" "Scan the QR code, or search my WeChat ID to add me — let’s talk AI, open source and the nomad life." | jsonify | safeJS }},
+    idLabel:    {{ cond $zh "微信号" "WeChat ID" | jsonify | safeJS }},
+    copy:       {{ cond $zh "复制微信号" "Copy ID" | jsonify | safeJS }},
+    copied:     {{ cond $zh "已复制 ✓" "Copied ✓" | jsonify | safeJS }},
+    scanHint:   {{ cond $zh "打开微信 →「扫一扫」" "Open WeChat · Scan" | jsonify | safeJS }},
+    qrAlt:      {{ cond $zh "微信二维码" "WeChat QR code" | jsonify | safeJS }},
+    close:      {{ cond $zh "关闭" "Close" | jsonify | safeJS }},
+    viewQr:     {{ cond $zh "查看大图" "View full size" | jsonify | safeJS }}
+  };
+
+  var backdrop = null, lastFocus = null;
+
+  function esc(s){ return String(s == null ? "" : s).replace(/[&<>"']/g, function(c){
+    return {"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[c];
+  }); }
+
+  function build(){
+    backdrop = document.createElement("div");
+    backdrop.id = "wechat-contact-backdrop";
+    backdrop.className = "wxc-backdrop";
+    backdrop.setAttribute("aria-hidden", "true");
+    backdrop.innerHTML = [
+      '<div class="wxc-card" role="dialog" aria-modal="true" aria-labelledby="wxc-title">',
+        '<button class="wxc-close" type="button" aria-label="' + esc(T.close) + '" onclick="closeWechatContact()">&#215;</button>',
+        '<div class="wxc-head">',
+          '<span class="wxc-logo" aria-hidden="true">',
+            '<svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">',
+              '<path d="M8.5 3C4.36 3 1 5.9 1 9.5c0 2.04 1.04 3.86 2.67 5.07L3 17l2.7-1.35A8.9 8.9 0 0 0 8.5 16c.17 0 .34 0 .51-.01A5.96 5.96 0 0 1 9 14.5c0-3.31 2.91-6 6.5-6 .17 0 .33.01.5.02C15.27 5.6 12.2 3 8.5 3zm-2 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm4 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm5.5 4C12.91 11.5 11 13.32 11 15.5s1.91 4 5 4c.64 0 1.25-.1 1.82-.28L20 20.5l-.5-2.14A3.97 3.97 0 0 0 21 15.5c0-2.18-1.91-4-5-4zm-1.5 2.5a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5zm3 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5z"/>',
+            '</svg>',
+          '</span>',
+          '<div class="wxc-headtext">',
+            '<h2 class="wxc-title" id="wxc-title">' + esc(T.title) + '</h2>',
+            '<span class="wxc-title-sub">' + esc(T.titleSub) + '</span>',
+          '</div>',
+        '</div>',
+        '<p class="wxc-lead">' + esc(T.lead) + '</p>',
+        '<a class="wxc-qr" href="#" target="_blank" rel="noopener" title="' + esc(T.viewQr) + '">',
+          '<span class="wxc-qr-frame">',
+            '<img class="wxc-qr-img" src="" alt="' + esc(T.qrAlt) + '" width="220" height="220" decoding="async" loading="lazy" />',
+            '<span class="wxc-scanline" aria-hidden="true"></span>',
+          '</span>',
+        '</a>',
+        '<p class="wxc-scanhint"><span class="wxc-scanhint-dot" aria-hidden="true"></span>' + esc(T.scanHint) + '</p>',
+        '<div class="wxc-id">',
+          '<span class="wxc-id-label">' + esc(T.idLabel) + '</span>',
+          '<code class="wxc-id-value"></code>',
+          '<button class="wxc-copy" type="button" onclick="copyWechatID(this)">',
+            '<svg class="wxc-copy-ico" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
+            '<span class="wxc-copy-txt">' + esc(T.copy) + '</span>',
+          '</button>',
+        '</div>',
+      '</div>'
+    ].join("");
+    backdrop.addEventListener("click", function (e) {
+      if (e.target === backdrop) closeWechatContact();
+    });
+    document.body.appendChild(backdrop);
+    return backdrop;
+  }
+
+  window.openWechatContact = function (btn) {
+    lastFocus = btn || document.activeElement;
+    var id = (btn && btn.getAttribute("data-wechat-id")) || "";
+    var qr = (btn && btn.getAttribute("data-wechat-qr")) || "";
+    if (!backdrop) build();
+
+    var img = backdrop.querySelector(".wxc-qr-img");
+    var frame = backdrop.querySelector(".wxc-qr-frame");
+    var link = backdrop.querySelector(".wxc-qr");
+    frame.classList.remove("is-loaded");
+    img.onload = function () { frame.classList.add("is-loaded"); };
+    img.src = qr;
+    link.setAttribute("href", qr);
+
+    backdrop.querySelector(".wxc-id-value").textContent = id;
+    backdrop.dataset.wechatId = id;
+
+    // reset copy button label
+    var txt = backdrop.querySelector(".wxc-copy-txt");
+    if (txt) txt.textContent = T.copy;
+    var copyBtn = backdrop.querySelector(".wxc-copy");
+    if (copyBtn) copyBtn.classList.remove("is-done");
+
+    backdrop.classList.add("is-open");
+    backdrop.setAttribute("aria-hidden", "false");
+    document.body.style.overflow = "hidden";
+    var closeBtn = backdrop.querySelector(".wxc-close");
+    if (closeBtn) setTimeout(function () { closeBtn.focus(); }, 60);
+  };
+
+  window.closeWechatContact = function () {
+    if (!backdrop) return;
+    backdrop.classList.remove("is-open");
+    backdrop.setAttribute("aria-hidden", "true");
+    document.body.style.overflow = "";
+    if (lastFocus && lastFocus.focus) { try { lastFocus.focus(); } catch (e) {} }
+  };
+
+  window.copyWechatID = function (el) {
+    var id = (backdrop && backdrop.dataset.wechatId) || "";
+    if (!id) return;
+    var done = function () {
+      var btn = el.closest ? el.closest(".wxc-copy") : el;
+      var txt = btn && btn.querySelector(".wxc-copy-txt");
+      if (btn) btn.classList.add("is-done");
+      if (txt) { txt.textContent = T.copied; setTimeout(function () {
+        txt.textContent = T.copy; btn.classList.remove("is-done");
+      }, 1800); }
+    };
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(id).then(done).catch(function () { fallback(id, done); });
+    } else { fallback(id, done); }
+  };
+
+  function fallback(text, cb) {
+    var ta = document.createElement("textarea");
+    ta.value = text; ta.setAttribute("readonly", "");
+    ta.style.position = "absolute"; ta.style.left = "-9999px";
+    document.body.appendChild(ta); ta.select();
+    try { document.execCommand("copy"); cb && cb(); } catch (e) {}
+    document.body.removeChild(ta);
+  }
+
+  document.addEventListener("keydown", function (e) {
+    if (e.key === "Escape" && backdrop && backdrop.classList.contains("is-open")) {
+      closeWechatContact();
+    }
+  });
+})();
+</script>


### PR DESCRIPTION
## What & why

Adds a personal **“Add me on WeChat”** experience to the site. WeChat has no clickable profile URL, so instead of a dead link it now opens a self-contained contact card showing my personal QR code and WeChat ID (`nsddd_top`) with one-tap copy.

## Changes

- **`config.yml`** — new `wechat` social entry (`wechatID: nsddd_top`, `qr: /wechat.jpg`).
- **Trigger button** rendered in three places, styled to match its neighbours:
  - homepage hero social row (`.hp-social-icon--wechat`)
  - homepage footer **Connect** list (`.hp-footer-wechat`)
  - shared `social_icons.html` partial (travel / profile pages)
- **`layouts/partials/wechat-contact.html`** — lazy-built modal: personal QR with an animated **scan-line** sweep + shimmer skeleton, copyable WeChat ID with a `navigator.clipboard` + `execCommand` fallback, pulsing scan hint, and bilingual copy driven by the page language (`jsonify | safeJS` for correct in-`<script>` escaping). Loaded once via `extend_footer.html`.
- **QR optimisation** — served through Hugo Pipes (`440x webp q88`, ~28 KB vs ~300 KB) and only fetched on first open, so there are **no third-party requests** and no impact on initial page load.
- **`assets/css/extended/zzz-wechat-contact.css`** — WeChat-green accents, theme-aware light/dark, responsive (full-width copy button on mobile), `prefers-reduced-motion` and `:focus-visible` support.

## Verification

Built with Hugo 0.145.0 extended and driven with Playwright (Chromium):

- ✅ Production build passes, minified, 1 processed image (the resized QR)
- ✅ Modal opens from hero icon **and** footer link
- ✅ Full `nsddd_top` renders; **Copy ID** writes `nsddd_top` to clipboard and toggles to “Copied ✓”
- ✅ Verified in **light / dark / mobile**, **EN / ZH** (Chinese primary text on the ZH page)
- ✅ No console/page errors introduced

## Notes

- QR image reused from the existing `static/wechat.jpg` / `assets/wechat.jpg`; the modal is intentionally distinct from the existing article-share WeChat QR (that one encodes the current page URL — this one is a personal contact card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xAzkhtHe3q6LyDe3DRKWB

---
_Generated by [Claude Code](https://claude.ai/code/session_016xAzkhtHe3q6LyDe3DRKWB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a WeChat contact card modal with QR code viewing, copy-to-clipboard, and quick close interactions.
  * WeChat social links now open an in-page dialog instead of navigating away.
  * Added WeChat support to the site’s social/contact areas, including the homepage and footer.
  * Introduced responsive, dark-mode, and reduced-motion-friendly styling for the new contact card UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->