### PR TITLE
feat(about): featured WeChat contact card + click-to-copy ID row

### DIFF
--- a/assets/css/extended/about.css
+++ b/assets/css/extended/about.css
@@ -306,6 +306,212 @@
   font-size: 0.85rem;
 }
 
+/* ── WeChat featured card ──────────────────────────────────────────────
+   The hero of the contact section: a full-width, WeChat-green accented
+   panel with a live mini-QR, copy-ready ID and a scan CTA. Clicking it
+   opens the site-wide contact dialog (openWechatContact). */
+.about-wechat {
+  --wx-green: #07c160;
+  --wx-green-strong: #06a850;
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  width: 100%;
+  margin: 0 0 20px;
+  padding: 22px 24px;
+  text-align: left;
+  cursor: pointer;
+  border: 1px solid color-mix(in srgb, var(--wx-green) 32%, var(--color-rule));
+  border-radius: var(--radius-xl);
+  background:
+    radial-gradient(120% 140% at 0% 0%, color-mix(in srgb, var(--wx-green) 12%, transparent), transparent 55%),
+    var(--color-paper);
+  color: var(--color-ink);
+  overflow: hidden;
+  isolation: isolate;
+  -webkit-tap-highlight-color: transparent;
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1),
+              border-color 220ms ease, box-shadow 220ms ease;
+}
+.about-wechat:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--wx-green) 60%, var(--color-rule));
+  box-shadow: 0 18px 42px -22px color-mix(in srgb, var(--wx-green) 70%, rgba(0, 0, 0, 0.5));
+}
+.about-wechat:active { transform: translateY(-1px) scale(0.995); }
+.about-wechat:focus-visible {
+  outline: 2px solid var(--wx-green);
+  outline-offset: 3px;
+}
+
+/* moving glow that follows the top-left corner on hover */
+.about-wechat-glow {
+  position: absolute;
+  top: -40%;
+  left: -10%;
+  width: 55%;
+  height: 180%;
+  z-index: -1;
+  background: radial-gradient(closest-side, color-mix(in srgb, var(--wx-green) 30%, transparent), transparent);
+  opacity: 0;
+  transform: translateX(-20px);
+  transition: opacity 320ms ease, transform 320ms ease;
+  pointer-events: none;
+}
+.about-wechat:hover .about-wechat-glow { opacity: 1; transform: translateX(0); }
+
+/* mini QR preview */
+.about-wechat-qr {
+  position: relative;
+  flex: none;
+  width: 96px;
+  height: 96px;
+  padding: 7px;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid color-mix(in srgb, var(--wx-green) 24%, var(--color-rule));
+  box-shadow: 0 8px 20px -12px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+.about-wechat-qr img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 6px;
+  display: block;
+}
+/* scan sweep across the mini QR */
+.about-wechat-scan {
+  position: absolute;
+  left: 7px;
+  right: 7px;
+  top: 7px;
+  height: 26px;
+  border-radius: 6px;
+  pointer-events: none;
+  opacity: 0;
+  background: linear-gradient(to bottom,
+    color-mix(in srgb, var(--wx-green) 0%, transparent),
+    color-mix(in srgb, var(--wx-green) 34%, transparent));
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--wx-green) 65%, transparent);
+}
+.about-wechat:hover .about-wechat-scan {
+  animation: about-wx-scan 1.8s cubic-bezier(0.6, 0, 0.4, 1) infinite;
+}
+@keyframes about-wx-scan {
+  0%   { transform: translateY(0);    opacity: 0; }
+  15%  { opacity: 1; }
+  85%  { opacity: 1; }
+  100% { transform: translateY(56px); opacity: 0; }
+}
+
+/* text body */
+.about-wechat-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+.about-wechat-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  color: var(--wx-green-strong);
+}
+.about-wechat-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 7px;
+  color: #fff;
+  background: linear-gradient(135deg, var(--wx-green), var(--wx-green-strong));
+  box-shadow: 0 4px 10px -5px color-mix(in srgb, var(--wx-green) 80%, transparent);
+  flex: none;
+}
+.about-wechat-badge svg { width: 14px; height: 14px; }
+.about-wechat-title {
+  font-size: 1.02rem;
+  font-weight: 700;
+  line-height: 1.35;
+  color: var(--color-ink);
+}
+.about-wechat-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 2px;
+}
+.about-wechat-id-label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--color-ink-muted);
+}
+.about-wechat-id-value {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  color: var(--color-ink);
+  padding: 2px 9px;
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--wx-green) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--wx-green) 20%, var(--color-rule));
+}
+
+/* CTA pill */
+.about-wechat-cta {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 9px 16px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #fff;
+  background: linear-gradient(135deg, var(--wx-green), var(--wx-green-strong));
+  box-shadow: 0 8px 18px -8px color-mix(in srgb, var(--wx-green) 75%, transparent);
+  transition: gap 200ms ease, box-shadow 200ms ease;
+}
+.about-wechat-cta svg { width: 16px; height: 16px; transition: transform 200ms ease; }
+.about-wechat:hover .about-wechat-cta { gap: 10px; }
+.about-wechat:hover .about-wechat-cta svg { transform: translateX(3px); }
+
+body.dark .about-wechat {
+  background:
+    radial-gradient(120% 140% at 0% 0%, color-mix(in srgb, var(--wx-green) 16%, transparent), transparent 55%),
+    color-mix(in srgb, var(--color-paper) 82%, transparent);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .about-wechat,
+  .about-wechat-glow,
+  .about-wechat-cta,
+  .about-wechat-cta svg { transition: none; }
+  .about-wechat:hover { transform: none; }
+  .about-wechat:hover .about-wechat-scan { animation: none; }
+}
+
+@media (max-width: 560px) {
+  .about-wechat {
+    flex-wrap: wrap;
+    gap: 16px;
+    padding: 18px;
+  }
+  .about-wechat-cta {
+    width: 100%;
+    justify-content: center;
+    order: 3;
+  }
+}
+
 /* ── Contact links ── */
 .about-links {
   display: grid;

--- a/assets/css/extended/zzz-wechat-contact.css
+++ b/assets/css/extended/zzz-wechat-contact.css
@@ -344,6 +344,22 @@
   border-radius: 13px;
   background: color-mix(in srgb, var(--primary) 4%, transparent);
   border: 1px solid var(--border);
+  cursor: pointer;
+  transition: border-color 0.18s ease, background 0.18s ease;
+}
+@media (hover: hover) and (pointer: fine) {
+  .wxc-id:hover {
+    border-color: color-mix(in srgb, var(--wx-green) 40%, var(--border));
+    background: color-mix(in srgb, var(--wx-green) 7%, transparent);
+  }
+}
+.wxc-id:focus-visible {
+  outline: 2px solid var(--wx-green);
+  outline-offset: 2px;
+}
+.wxc-id.is-done {
+  border-color: color-mix(in srgb, var(--wx-green) 55%, var(--border));
+  background: color-mix(in srgb, var(--wx-green) 12%, transparent);
 }
 .wxc-id-label {
   flex: none;

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -131,6 +131,36 @@ tldr:
 
 <section class="about-section">
   <h2 class="about-section-title"><span class="about-section-icon">📬</span>Get in Touch</h2>
+
+  <button type="button" class="about-wechat"
+          aria-haspopup="dialog"
+          data-wechat-id="nsddd_top"
+          data-wechat-qr="/wechat.jpg"
+          onclick="openWechatContact(this)">
+    <span class="about-wechat-glow" aria-hidden="true"></span>
+    <span class="about-wechat-qr" aria-hidden="true">
+      <img src="/wechat.jpg" alt="" width="120" height="120" loading="lazy" decoding="async">
+      <span class="about-wechat-scan"></span>
+    </span>
+    <span class="about-wechat-body">
+      <span class="about-wechat-eyebrow">
+        <span class="about-wechat-badge">
+          <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8.5 3C4.36 3 1 5.9 1 9.5c0 2.04 1.04 3.86 2.67 5.07L3 17l2.7-1.35A8.9 8.9 0 0 0 8.5 16c.17 0 .34 0 .51-.01A5.96 5.96 0 0 1 9 14.5c0-3.31 2.91-6 6.5-6 .17 0 .33.01.5.02C15.27 5.6 12.2 3 8.5 3zm-2 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm4 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm5.5 4C12.91 11.5 11 13.32 11 15.5s1.91 4 5 4c.64 0 1.25-.1 1.82-.28L20 20.5l-.5-2.14A3.97 3.97 0 0 0 21 15.5c0-2.18-1.91-4-5-4zm-1.5 2.5a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5zm3 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5z"/></svg>
+        </span>
+        WeChat · Fastest way to reach me
+      </span>
+      <span class="about-wechat-title">Add me on WeChat — let's talk AI &amp; remote life</span>
+      <span class="about-wechat-id">
+        <span class="about-wechat-id-label">WeChat ID</span>
+        <span class="about-wechat-id-value">nsddd_top</span>
+      </span>
+    </span>
+    <span class="about-wechat-cta" aria-hidden="true">
+      <span class="about-wechat-cta-text">Scan to add</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </span>
+  </button>
+
   <div class="about-links">
     <a class="about-link-item" href="https://github.com/cubxxw" target="_blank" rel="noopener">
       <span class="about-link-icon">🐙</span>

--- a/content/zh/about.md
+++ b/content/zh/about.md
@@ -131,6 +131,36 @@ tldr:
 
 <section class="about-section">
   <h2 class="about-section-title"><span class="about-section-icon">📬</span>如何联系我</h2>
+
+  <button type="button" class="about-wechat"
+          aria-haspopup="dialog"
+          data-wechat-id="nsddd_top"
+          data-wechat-qr="/wechat.jpg"
+          onclick="openWechatContact(this)">
+    <span class="about-wechat-glow" aria-hidden="true"></span>
+    <span class="about-wechat-qr" aria-hidden="true">
+      <img src="/wechat.jpg" alt="" width="120" height="120" loading="lazy" decoding="async">
+      <span class="about-wechat-scan"></span>
+    </span>
+    <span class="about-wechat-body">
+      <span class="about-wechat-eyebrow">
+        <span class="about-wechat-badge">
+          <svg viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M8.5 3C4.36 3 1 5.9 1 9.5c0 2.04 1.04 3.86 2.67 5.07L3 17l2.7-1.35A8.9 8.9 0 0 0 8.5 16c.17 0 .34 0 .51-.01A5.96 5.96 0 0 1 9 14.5c0-3.31 2.91-6 6.5-6 .17 0 .33.01.5.02C15.27 5.6 12.2 3 8.5 3zm-2 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm4 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm5.5 4C12.91 11.5 11 13.32 11 15.5s1.91 4 5 4c.64 0 1.25-.1 1.82-.28L20 20.5l-.5-2.14A3.97 3.97 0 0 0 21 15.5c0-2.18-1.91-4-5-4zm-1.5 2.5a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5zm3 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5z"/></svg>
+        </span>
+        微信 · 最快找到我
+      </span>
+      <span class="about-wechat-title">加我的微信，一起聊 AI 与远程生活</span>
+      <span class="about-wechat-id">
+        <span class="about-wechat-id-label">微信号</span>
+        <span class="about-wechat-id-value">nsddd_top</span>
+      </span>
+    </span>
+    <span class="about-wechat-cta" aria-hidden="true">
+      <span class="about-wechat-cta-text">扫码添加</span>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+    </span>
+  </button>
+
   <div class="about-links">
     <a class="about-link-item" href="https://github.com/cubxxw" target="_blank" rel="noopener">
       <span class="about-link-icon">🐙</span>

--- a/layouts/partials/wechat-contact.html
+++ b/layouts/partials/wechat-contact.html
@@ -55,10 +55,10 @@
           '</span>',
         '</a>',
         '<p class="wxc-scanhint"><span class="wxc-scanhint-dot" aria-hidden="true"></span>' + esc(T.scanHint) + '</p>',
-        '<div class="wxc-id">',
+        '<div class="wxc-id" role="button" tabindex="0" title="' + esc(T.copy) + '" onclick="copyWechatID(this)" onkeydown="if(event.key===\'Enter\'||event.key===\' \'){event.preventDefault();copyWechatID(this);}">',
           '<span class="wxc-id-label">' + esc(T.idLabel) + '</span>',
           '<code class="wxc-id-value"></code>',
-          '<button class="wxc-copy" type="button" onclick="copyWechatID(this)">',
+          '<button class="wxc-copy" type="button" tabindex="-1" onclick="event.stopPropagation();copyWechatID(this)">',
             '<svg class="wxc-copy-ico" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>',
             '<span class="wxc-copy-txt">' + esc(T.copy) + '</span>',
           '</button>',
@@ -114,12 +114,22 @@
     var id = (backdrop && backdrop.dataset.wechatId) || "";
     if (!id) return;
     var done = function () {
-      var btn = el.closest ? el.closest(".wxc-copy") : el;
+      // The copy action fires from two places: the .wxc-copy button itself,
+      // or the whole .wxc-id row. Resolve the button either way so the label
+      // + done-state land on the pill regardless of which was clicked.
+      var btn = (el.closest && el.closest(".wxc-copy")) ||
+                (backdrop && backdrop.querySelector(".wxc-copy"));
+      var row = (el.closest && el.closest(".wxc-id")) ||
+                (backdrop && backdrop.querySelector(".wxc-id"));
       var txt = btn && btn.querySelector(".wxc-copy-txt");
       if (btn) btn.classList.add("is-done");
-      if (txt) { txt.textContent = T.copied; setTimeout(function () {
-        txt.textContent = T.copy; btn.classList.remove("is-done");
-      }, 1800); }
+      if (row) row.classList.add("is-done");
+      if (txt) { txt.textContent = T.copied; }
+      setTimeout(function () {
+        if (txt) txt.textContent = T.copy;
+        if (btn) btn.classList.remove("is-done");
+        if (row) row.classList.remove("is-done");
+      }, 1800);
     };
     if (navigator.clipboard && navigator.clipboard.writeText) {
       navigator.clipboard.writeText(id).then(done).catch(function () { fallback(id, done); });


### PR DESCRIPTION
## 背景
About 页面的"如何联系我"区块列出了 GitHub / Email / X / 知乎 / 即刻 / Bilibili 等，唯独**没有微信**——精致的微信联系弹窗此前只挂在首页社交栏，About 页反而缺失入口。

## 改动
**About 页面微信主卡片（中英双语）**
- 横跨整行的微信绿主题面板，作为联系区块的视觉焦点
- 迷你二维码实时预览 + 悬浮扫描光束
- 微信 logo 徽章 + `nsddd_top` 微信号 pill + "扫码添加 →" CTA
- 悬浮上浮 + 边角光晕；点击调起已有的全站 `openWechatContact()` 弹窗
- 主题自适应（亮/暗）、`prefers-reduced-motion` 安全、移动端优雅换行

**弹窗交互增强**
- 整个微信号行可点击复制（不只小按钮），支持 Enter/Space 键盘操作
- 复制成功时行 + 按钮同步变绿

## 验证（headless 浏览器）
- ✅ 中英文两版渲染 + 弹窗打开
- ✅ 整行复制 + 按钮复制都生效
- ✅ 亮色/暗色均清晰可读
- ✅ 390px 无横向溢出、CTA 全宽换行
- ✅ 0 控制台错误、0 构建错误

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new WeChat contact card to the About page in both English and Chinese.
  * Users can now tap the card, view a QR preview, and copy the WeChat ID more easily.

* **Bug Fixes**
  * Improved the copy interaction so both the ID row and copy button behave consistently.
  * Added clearer keyboard and focus support for better accessibility.

* **Style**
  * Introduced refreshed WeChat-themed visual styling, hover effects, and responsive layout adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->