### PR TITLE
feat(ai): make Bear AI contact-aware — answer WeChat/contact + one-tap card

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -5546,6 +5546,32 @@ pre:hover .copy-code {
 .ai-retry-btn { margin-top: 6px; padding: 3px 10px; border-radius: 8px; border: 1px solid currentColor; opacity: 0.7; cursor: pointer; background: transparent; font-size: 0.85em; }
 .ai-retry-btn:hover { opacity: 1; }
 
+/* Contact-aware WeChat quick action under an AI answer */
+.ai-wechat-cta { margin: 10px 0 4px; }
+.ai-wechat-cta-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 16px;
+  border: none;
+  border-radius: 999px;
+  font-size: 0.85em;
+  font-weight: 600;
+  color: #fff;
+  cursor: pointer;
+  background: linear-gradient(135deg, #07c160, #06a850);
+  box-shadow: 0 6px 16px -8px rgba(7, 193, 96, 0.75);
+  transition: transform 0.16s ease, box-shadow 0.16s ease, gap 0.16s ease;
+}
+.ai-wechat-cta-btn svg { flex: none; }
+.ai-wechat-cta-btn:hover { transform: translateY(-1px); gap: 9px; box-shadow: 0 10px 22px -8px rgba(7, 193, 96, 0.8); }
+.ai-wechat-cta-btn:active { transform: translateY(0) scale(0.97); }
+.ai-wechat-cta-btn:focus-visible { outline: 2px solid #07c160; outline-offset: 2px; }
+@media (prefers-reduced-motion: reduce) {
+  .ai-wechat-cta-btn { transition: none; }
+  .ai-wechat-cta-btn:hover { transform: none; }
+}
+
 /* blog-ai-inline suggestion buttons */
 .blog-ai-suggestions { display: flex; gap: 6px; flex-wrap: wrap; padding: 6px 0 4px; }
 .blog-ai-suggestion { padding: 3px 10px; border-radius: 14px; border: 1px solid rgba(99,102,241,0.3); background: transparent; cursor: pointer; font-size: 0.82em; color: inherit; transition: background 0.15s; }

--- a/assets/js/search-palette.js
+++ b/assets/js/search-palette.js
@@ -264,6 +264,10 @@
 
       // Attach event listeners to follow-up elements
       attachFollowUpListeners();
+
+      // Contact-aware quick action: if the answer is about WeChat/contact,
+      // surface a one-tap button that opens the site-wide WeChat card.
+      maybeAddWechatCTA(answer);
     } catch (err) {
       clearTimeout(aiTimeoutId);
       console.error('AI Error:', err);
@@ -343,6 +347,35 @@
       `<a href="${c.permalink}" class="ai-source-link" target="_blank">${c.title}</a>`
     ).join('');
     return `<div class="ai-sources"><span class="ai-sources-label">参考 / Sources: </span>${links}</div>`;
+  }
+
+  // When an AI answer is about WeChat / contact, append a one-tap button that
+  // opens the site-wide WeChat card (QR + copy). No-op if the WeChat helper or
+  // trigger isn't on the page.
+  function maybeAddWechatCTA(answer) {
+    if (typeof window.openWechatContact !== 'function') return;
+    const trigger = document.querySelector('[data-wechat-id][data-wechat-qr]');
+    if (!trigger || !aiContent) return;
+    if (!/(wechat|微信|nsddd_top)/i.test(String(answer || ''))) return;
+    if (aiContent.querySelector('.ai-wechat-cta')) return; // avoid dupes on follow-ups
+
+    const isZh = (document.documentElement.lang || '').toLowerCase().indexOf('zh') === 0;
+    const wrap = document.createElement('div');
+    wrap.className = 'ai-wechat-cta';
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'ai-wechat-cta-btn';
+    btn.innerHTML =
+      '<svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16" aria-hidden="true"><path d="M8.5 3C4.36 3 1 5.9 1 9.5c0 2.04 1.04 3.86 2.67 5.07L3 17l2.7-1.35A8.9 8.9 0 0 0 8.5 16c.17 0 .34 0 .51-.01A5.96 5.96 0 0 1 9 14.5c0-3.31 2.91-6 6.5-6 .17 0 .33.01.5.02C15.27 5.6 12.2 3 8.5 3zm-2 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm4 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm5.5 4C12.91 11.5 11 13.32 11 15.5s1.91 4 5 4c.64 0 1.25-.1 1.82-.28L20 20.5l-.5-2.14A3.97 3.97 0 0 0 21 15.5c0-2.18-1.91-4-5-4zm-1.5 2.5a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5zm3 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5z"/></svg>' +
+      '<span>' + (isZh ? '打开微信名片' : 'Open WeChat card') + '</span>';
+    btn.addEventListener('click', function () {
+      try { window.openWechatContact(trigger); } catch (e) {}
+    });
+    wrap.appendChild(btn);
+    // Insert right after the last assistant turn, before the follow-up input.
+    const followUp = aiContent.querySelector('.search-palette__followup');
+    if (followUp) aiContent.insertBefore(wrap, followUp);
+    else aiContent.appendChild(wrap);
   }
 
   function formatAiAnswer(text) {

--- a/netlify/functions/blog-ai.js
+++ b/netlify/functions/blog-ai.js
@@ -8,6 +8,26 @@ const { stream: netlifyStream } = require("@netlify/functions");
 const indexPath = path.join(__dirname, "_generated", "content-index.json");
 let cachedIndex = null;
 
+// Authoritative author + contact card. Keep in sync with config.yml
+// (params.socialIcons) — this is what lets Bear AI answer "how do I reach
+// the author / what's his WeChat" instead of falling back to "articles only".
+const AUTHOR_PROFILE = [
+  "Name: 熊鑫伟 (Xinwei Xiong), handle cubxxw. Born 2001 in China.",
+  "Identity: AI founder, open-source contributor, digital nomad and writer. Believes AI + Human = Superhuman. Active in OpenIM, OpenKF, Sealos.",
+  "Personality: authentic, curious, a connector — happy to talk AI, open source and the nomad life.",
+  "Contact channels:",
+  "- WeChat (微信, the fastest way to reach him) — WeChat ID: nsddd_top. QR code + one-click copy available via the WeChat card.",
+  "- Email: 3293172751nss@gmail.com",
+  "- GitHub: https://github.com/cubxxw",
+  "- X / Twitter: https://x.com/xxw3293172751",
+  "- 知乎 / Zhihu: https://www.zhihu.com/people/3293172751",
+  "- 即刻 / Jike: https://web.okjike.com/u/56390e30-3288-4d20-a488-9f80161bbbf4",
+  "- Bilibili: https://space.bilibili.com/1233089591",
+  "- 小红书 / Xiaohongshu: https://www.xiaohongshu.com/user/profile/62a33af9000000001b025dd3",
+  "- Buy Me a Coffee: https://www.buymeacoffee.com/cubxxw",
+  "Full contact section lives on the About page: https://nsddd.top/zh/about/ (English: https://nsddd.top/about/).",
+].join("\n");
+
 function loadIndex() {
   if (cachedIndex) return cachedIndex;
   cachedIndex = JSON.parse(fs.readFileSync(indexPath, "utf8"));
@@ -124,6 +144,13 @@ async function handler(event) {
     "Do not invent permalinks or titles not present in the provided candidate documents.",
     "If conversation history is provided, use it to maintain context and provide more personalized responses.",
     "For follow-up questions, consider them in the context of the conversation history and provide coherent, connected responses.",
+    "",
+    "AUTHOR PROFILE — you know the blog's author personally and may answer questions about who he is and how to reach him, even though this is not in the article list:",
+    AUTHOR_PROFILE,
+    "",
+    "CONTACT RULE — when the user asks how to contact the author, or asks for his WeChat / 微信 / email / GitHub / social accounts, answer warmly and directly using the AUTHOR PROFILE above. Never say you can only answer article questions, and never invent contact details not listed in the profile.",
+    "When WeChat / 微信 is asked for specifically, state the WeChat ID (nsddd_top) and then guide the user to the WeChat card: tell them to click the WeChat icon in the top-right social row (or the WeChat card on the About page) to open the QR code and one-click copy the ID. Provide the About page link [关于我 / About](https://nsddd.top/zh/about/) so they can reach the full contact section.",
+    "Keep contact answers friendly and human — the author is open, curious and happy to connect about AI, open source and the nomad life.",
   ].join(" ");
 
   const messages = [{ role: "system", content: systemPrompt }];

--- a/static/js/blog-ai-inline.js
+++ b/static/js/blog-ai-inline.js
@@ -278,6 +278,33 @@
       messages.scrollTop = messages.scrollHeight;
     }
 
+    // When the answer is about WeChat / contact, surface a one-tap button
+    // that opens the site-wide WeChat card (QR + copy). Turns a text answer
+    // into a direct action. No-op when the WeChat helper isn't on the page.
+    function maybeAddWechatCTA(answer) {
+      if (typeof window.openWechatContact !== "function") return;
+      const trigger = document.querySelector("[data-wechat-id][data-wechat-qr]");
+      if (!trigger) return;
+      const text = String(answer || "");
+      if (!/(wechat|微信|nsddd_top)/i.test(text)) return;
+
+      const wrap = document.createElement("div");
+      wrap.className = "ai-wechat-cta";
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "ai-wechat-cta-btn";
+      const label = language === "zh" ? "打开微信名片" : "Open WeChat card";
+      btn.innerHTML =
+        '<svg viewBox="0 0 24 24" fill="currentColor" width="16" height="16" aria-hidden="true"><path d="M8.5 3C4.36 3 1 5.9 1 9.5c0 2.04 1.04 3.86 2.67 5.07L3 17l2.7-1.35A8.9 8.9 0 0 0 8.5 16c.17 0 .34 0 .51-.01A5.96 5.96 0 0 1 9 14.5c0-3.31 2.91-6 6.5-6 .17 0 .33.01.5.02C15.27 5.6 12.2 3 8.5 3zm-2 4.5a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm4 0a1 1 0 1 1 0 2 1 1 0 0 1 0-2zm5.5 4C12.91 11.5 11 13.32 11 15.5s1.91 4 5 4c.64 0 1.25-.1 1.82-.28L20 20.5l-.5-2.14A3.97 3.97 0 0 0 21 15.5c0-2.18-1.91-4-5-4zm-1.5 2.5a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5zm3 0a.75.75 0 1 1 0 1.5.75.75 0 0 1 0-1.5z"/></svg>' +
+        "<span>" + label + "</span>";
+      btn.addEventListener("click", function () {
+        try { window.openWechatContact(trigger); } catch (e) {}
+      });
+      wrap.appendChild(btn);
+      messages.appendChild(wrap);
+      messages.scrollTop = messages.scrollHeight;
+    }
+
     function showLoading() {
       const msg = document.createElement("div");
       msg.className = "blog-ai-message blog-ai-message-ai blog-ai-loading";
@@ -374,6 +401,9 @@
           messages.appendChild(sourcesDiv);
           messages.scrollTop = messages.scrollHeight;
         }
+
+        // Contact-aware quick action: open the WeChat card in one tap
+        maybeAddWechatCTA(answer);
 
         // Save to context
         conversationContext = addToContext(conversationContext, question, answer);


### PR DESCRIPTION
## 问题
向站点 AI 提问"作者的微信是多少 / 怎么联系他"时，回答很生硬：Bear AI 是纯文章 RAG，系统提示词只会推荐文章，内容索引里也没有联系方式——于是它要么回避，要么有编造风险。

## 深度分析
两个 AI 入口（顶部 ⌘K 搜索面板的 "Ask bear AI" + 文章内 widget）都打同一个 `netlify/functions/blog-ai`。根因在后端系统提示词缺少作者档案。

## 解决方案（两层）
**1. 后端** — 注入权威 `AUTHOR_PROFILE`（姓名、身份 + config.yml 里的全部联系渠道：微信 `nsddd_top`、邮箱、GitHub、X、知乎、即刻、Bilibili、小红书、BMC），并加 CONTACT RULE：友好准确作答、给出微信号、引导到微信卡片 + 关于我页。两个入口同时受益。

**2. 前端** — 回答里出现微信/微信号时，浮现微信绿"打开微信名片 / Open WeChat card"按钮，一键调起已有的全站微信弹窗（二维码 + 一键复制）。`search-palette.js` 和 `blog-ai-inline.js` 都加了，页面无微信触发器时自动降级为 no-op。

## 验证（netlify dev + headless）
- ✅ 中/英"作者微信"提问 → 准确作答 + 链接
- ✅ 回答下方浮现绿色 CTA 按钮
- ✅ 点击 → 微信卡片弹出（二维码 + nsddd_top + 一键复制）
- ✅ "作者是谁"也能优雅介绍身份 + 联系方式
- ✅ 0 控制台错误