### PR TITLE
perf(fonts): 修复中文文章标题 LCP —— 本地衬线字体优先,不再阻塞于 Google Fonts

### DIFF
--- a/assets/css/extended/nav-elegant.css
+++ b/assets/css/extended/nav-elegant.css
@@ -297,7 +297,7 @@ body.dark #theme-toggle:hover {
 /* Chinese glyph (中) gets a serif face for character feel */
 .lang-switch__item--zh > a,
 .lang-switch__item--zh > span {
-    font-family: "Noto Serif SC", "Source Han Serif SC", var(--font-serif, serif);
+    font-family: "Source Han Serif SC", "Songti SC", "Noto Serif SC", var(--font-serif, serif);
     font-size: 13px;
     letter-spacing: 0;
 }

--- a/assets/css/extended/tokens.css
+++ b/assets/css/extended/tokens.css
@@ -85,11 +85,17 @@ html:lang(zh) {
   --color-accent-soft:  #eae8e3;
   --color-rule:         rgba(53, 0, 3, 0.10);
 
-  /* Songti SC / STSong sit before the sans fallbacks so the long
-     Noto Serif SC webfont download (dozens of CJK unicode-range
-     subsets) swaps serif→serif instead of flashing sans first. */
-  --font-display: 'Noto Serif SC', 'Source Han Serif SC', 'Songti SC',
-                  'STSong', 'SimSun', 'PingFang SC', 'Hiragino Sans GB',
+  /* LCP fix: the H1 title is the LCP element on long ZH posts, and the
+     Noto Serif SC webfont (dozens of CJK unicode-range subsets) loads from
+     fonts.gstatic.com — slow/blocked from PSI probes & mainland networks,
+     which pushed title LCP to 16–19s (issue #222/#223). Local system serifs
+     (Source Han / Songti / STSong) now sit FIRST so the title paints
+     instantly from the visitor's own fonts; Noto Serif SC still upgrades
+     the glyphs seamlessly once it arrives, but LCP no longer waits on it.
+     The families are near-identical serif designs, so there is no visual
+     regression for the common macOS/Windows reader. */
+  --font-display: 'Source Han Serif SC', 'Songti SC', 'STSong', 'SimSun',
+                  'Noto Serif SC', 'PingFang SC', 'Hiragino Sans GB',
                   'Microsoft YaHei', serif;
   --font-body:    'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei',
                   system-ui, sans-serif;

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -48,7 +48,10 @@
 {{- $defaultOgImage := index (site.Params.images | default (slice "/assets/og-image.png")) 0 -}}
 {{- $sectionOgImage := index $sectionDefault .Section | default $defaultOgImage -}}
 {{- $ogImage := $sectionOgImage -}}
-{{- with .Params.cover.image -}}{{- $ogImage = . -}}{{- end -}}
+{{- /* Social/search crawlers (Bing thumbnails, WeChat/X/LinkedIn/FB cards) reject
+       SVG as a preview image — they need a raster 1200×630. Only override with the
+       cover when it's NOT an SVG; otherwise keep the section/default PNG. */ -}}
+{{- with .Params.cover.image -}}{{- if not (strings.HasSuffix (lower .) ".svg") -}}{{- $ogImage = . -}}{{- end -}}{{- end -}}
 <meta property="og:image" content="{{ $ogImage | absURL }}" />
 <meta property="og:image:alt" content="{{ with .Params.cover.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" />
 <meta property="og:image:width" content="1200" />


### PR DESCRIPTION
## 背景

每日 SEO 观察 issue #222 / #223 连续多天报告 `/zh/growth/posts/2025-annual-review/` 移动端 **LCP 高达 16–19.8s**,并反复建议「压缩 `lhasa-life.jpg` / `tibet-drive.jpg` 两张图片」。

## 诊断:图片是误判,根因是标题字体

用 headless 浏览器实测(buffered LCP observer)确认:

- **LCP 元素是 `<h1 class="post-title">` 中文标题文字,不是图片。**
- 那两张图早已被 `render-image` hook 优化成 480/768/1000w 的 WebP+JPG `srcset`、`loading=lazy`,且位于正文第 200 行 —— 与 LCP 完全无关,压缩它们不会改善分数。之前的建议只看了 page bundle 里的原始文件大小,没意识到 hook 已优化 + 懒加载。
- H1 标题的字体栈第一顺位是 `Noto Serif SC` —— 从 `fonts.gstatic.com` 加载的 Google 中文 webfont(几十个 CJK unicode-range 子集)。这条链路在 PSI 探测节点和大陆网络上慢/被墙,把标题 LCP 拖到 16–19s;字体缓存命中的日子又降到 ~0.8s —— 正好解释了「每天剧烈跳动」。

## 修复

把本地系统衬线字体(`Source Han Serif SC` / `Songti SC` / `STSong`)提到 `Noto Serif SC` **之前**:

- `assets/css/extended/tokens.css` — `html:lang(zh)` 的 `--font-display`
- `assets/css/extended/nav-elegant.css` — 语言切换器「中」字符

标题现在用访客本机字体**立即渲染**,`Noto Serif SC` 到了再无缝升级字形,但 LCP 不再等 gstatic。本地字体与 Noto Serif SC 近乎同源,常见 macOS/Windows 访客无视觉回归。

## 验证

- `hugo` 构建通过,页面 HTTP 200
- headless 实测:H1 computed `font-family` 首位已变为 `Source Han Serif SC`,`Noto Serif SC` 退到第 5 位可选升级
- LCP 元素不再绑定 webfont

## 附带改动

- `fix(seo)`:封面为 SVG 时 `og:image` 回退到栏目/默认 PNG(社交/搜索爬虫拒绝 SVG 预览图),独立合理的遗留改动,单独 commit。

## 后续(不在本 PR)

原始大图仍作为 page bundle 死重发布进 `public`(~677KB,无 HTML 引用,不影响 LCP)—— 独立的部署体积优化项,留待单独处理。

Refs #222, #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Chinese typography by prioritizing local Han serif fonts for a more consistent display.
  * Updated Chinese font loading behavior to improve page performance.
  * Prevented SVG cover images from being used in social media previews, preserving compatible fallback images instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->