### PR TITLE
perf(mobile): 精简文章页移动端悬浮控件 + ZH 标题字体 LCP + OG 图修复

### DIFF
--- a/assets/css/extended/article-bottom-sheet.css
+++ b/assets/css/extended/article-bottom-sheet.css
@@ -2,29 +2,53 @@
 
 /* Only visible on mobile (<1024px) */
 
-/* ── Floating Action Button ────────────────────────────────── */
+/* ── Floating Action Button ──────────────────────────────────
+   The single mobile floating control (the back-to-top orb is gone on
+   phones — see zzz-mobile-back-to-top.css). Tuned to be as quiet as a
+   floating control can be: small, dimmed and semi-transparent at rest
+   so it barely marks the page, then lifting to full presence only when
+   the finger arrives (:active) or focus lands on it. It sits in the
+   very bottom-right corner now that nothing stacks beneath it. */
 .article-fab {
   display: none;
   position: fixed;
-  bottom: 6.5rem;
-  right: 1.25rem;
-  width: 48px;
-  height: 48px;
+  /* Down in the corner, clear of the home-indicator safe area. */
+  bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
+  right: 1rem;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
-  background: var(--color-accent, #2e352e);
+  /* Translucent accent so the paper shows through — a hint, not a slab.
+     color-mix keeps it on-brand (accent) while cutting its weight; the
+     rgba fallback covers browsers without color-mix. */
+  background: rgba(46, 53, 46, 0.55);
+  background: color-mix(in srgb, var(--color-accent, #2e352e) 62%, transparent);
   color: var(--color-paper, #f9f9f7);
   border: none;
   cursor: pointer;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.18);
+  /* Soft, low shadow — presence without a hard drop. */
+  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.12);
+  -webkit-backdrop-filter: blur(6px);
+          backdrop-filter: blur(6px);
+  -webkit-tap-highlight-color: transparent;
+  opacity: 0.62;              /* dimmed at rest so it recedes into the read */
   z-index: 200;
-  transition: opacity 240ms ease, transform 240ms ease;
+  transition: opacity 240ms ease, transform 240ms ease, background-color 200ms ease;
+}
+
+/* Finger on it (or focused): come fully forward, solid accent. */
+.article-fab:active,
+.article-fab:focus-visible {
+  opacity: 1;
+  background: var(--color-accent, #2e352e);
+  transform: scale(0.94);
 }
 
 .article-fab svg {
-  width: 20px;
-  height: 20px;
+  width: 18px;
+  height: 18px;
   pointer-events: none;
 }
 

--- a/assets/css/extended/nav-elegant.css
+++ b/assets/css/extended/nav-elegant.css
@@ -297,7 +297,7 @@ body.dark #theme-toggle:hover {
 /* Chinese glyph (中) gets a serif face for character feel */
 .lang-switch__item--zh > a,
 .lang-switch__item--zh > span {
-    font-family: "Noto Serif SC", "Source Han Serif SC", var(--font-serif, serif);
+    font-family: "Source Han Serif SC", "Songti SC", "Noto Serif SC", var(--font-serif, serif);
     font-size: 13px;
     letter-spacing: 0;
 }

--- a/assets/css/extended/tokens.css
+++ b/assets/css/extended/tokens.css
@@ -85,11 +85,17 @@ html:lang(zh) {
   --color-accent-soft:  #eae8e3;
   --color-rule:         rgba(53, 0, 3, 0.10);
 
-  /* Songti SC / STSong sit before the sans fallbacks so the long
-     Noto Serif SC webfont download (dozens of CJK unicode-range
-     subsets) swaps serif→serif instead of flashing sans first. */
-  --font-display: 'Noto Serif SC', 'Source Han Serif SC', 'Songti SC',
-                  'STSong', 'SimSun', 'PingFang SC', 'Hiragino Sans GB',
+  /* LCP fix: the H1 title is the LCP element on long ZH posts, and the
+     Noto Serif SC webfont (dozens of CJK unicode-range subsets) loads from
+     fonts.gstatic.com — slow/blocked from PSI probes & mainland networks,
+     which pushed title LCP to 16–19s (issue #222/#223). Local system serifs
+     (Source Han / Songti / STSong) now sit FIRST so the title paints
+     instantly from the visitor's own fonts; Noto Serif SC still upgrades
+     the glyphs seamlessly once it arrives, but LCP no longer waits on it.
+     The families are near-identical serif designs, so there is no visual
+     regression for the common macOS/Windows reader. */
+  --font-display: 'Source Han Serif SC', 'Songti SC', 'STSong', 'SimSun',
+                  'Noto Serif SC', 'PingFang SC', 'Hiragino Sans GB',
                   'Microsoft YaHei', serif;
   --font-body:    'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei',
                   system-ui, sans-serif;

--- a/assets/css/extended/zzz-mobile-back-to-top.css
+++ b/assets/css/extended/zzz-mobile-back-to-top.css
@@ -1,81 +1,34 @@
 /* ============================================================
-   zzz-mobile-back-to-top.css — direction-aware back-to-top (mobile)
+   zzz-mobile-back-to-top.css — back-to-top is DESKTOP-ONLY
    ------------------------------------------------------------
    On desktop the #top-link control springs in past 800px and fills
    a progress ring as you read (footer.html + micro-interactions.css
-   + zz-scroll-detail.css). On phones it was hidden outright
-   (custom.css → `@media (max-width:1023px){ .top-link{display:none} }`)
+   + zz-scroll-detail.css). custom.css already hides it on phones
+   (`@media (max-width:1023px){ .top-link{display:none !important} }`)
    to avoid a control parked permanently over the content.
 
-   This layer brings it back on mobile — but only as a *gesture
-   response*, never a persistent overlay: the button stays tucked
-   away and reveals only when the reader swipes UP (an intent to go
-   back), then hides again on the next downward scroll or near the
-   top. The reveal is driven by `.is-visible-mobile`, toggled in
-   micro-interactions.js. This honours the original "don't clutter
-   the read" intent while answering the very gesture — scrolling up —
-   with the shortcut it implies.
+   An earlier iteration re-introduced it on mobile as a swipe-up
+   "gesture response". In practice that put a SECOND floating orb in
+   the bottom-right corner, stacked under the article FAB — two round
+   controls fighting for the same corner over the live read. The
+   mobile brief is the opposite: as few floating controls as possible,
+   so the reader sees the article, not the chrome.
 
-   Loads late (zzz- prefix) so these rules win source-order against
-   custom.css; the `!important` here is the minimum needed to defeat
-   the earlier `display:none !important`. Fully neutralised under
-   reduced motion (fade only, no travel) at the foot of the file.
+   So on mobile the back-to-top button is gone entirely. The single
+   article FAB (article-bottom-sheet.css) is the ONE mobile floating
+   control; its bottom-sheet already carries every tool a phone reader
+   needs (Contents / Series / AI / Share), and its Contents tab jumps
+   straight back to any heading — including the top. This file now
+   only hard-guarantees the phone hide so no later layer can revive
+   the orb; desktop behaviour is untouched (rules live elsewhere).
    ============================================================ */
 
 @media (max-width: 1023px) {
-  /* Re-enable the control on phones, but born hidden: shifted down,
-     shrunk and click-through until a scroll-up reveals it. */
-  .top-link {
-    display: flex !important;
-    align-items: center;
-    justify-content: center;
-    /* Sit clear of the home-indicator / safe area on modern phones. */
-    bottom: calc(20px + env(safe-area-inset-bottom, 0px));
-    right: 16px;
-    width: 44px;   /* keep a 44px tap target */
-    height: 44px;
-    opacity: 0;
-    visibility: hidden;
-    pointer-events: none;
-    transform: translateY(14px) scale(0.72);
-    transition:
-      opacity 0.28s ease,
-      visibility 0.28s ease,
-      transform 0.32s cubic-bezier(0.34, 1.56, 0.64, 1);
-  }
-
-  /* Revealed: the button rises and settles with a gentle overshoot. */
+  /* One floating control on phones, and it isn't this one. Keep the
+     control fully removed — not just faded — so it can never overlap
+     the FAB or intercept a tap over the content. */
+  .top-link,
   .top-link.is-visible-mobile {
-    opacity: 1;
-    visibility: visible;
-    pointer-events: auto;
-    transform: translateY(0) scale(1);
-  }
-
-  /* Tactile press for the finger — a quick squash on tap. The
-     reveal class keeps it composed so :active never snaps it back to
-     the hidden resting transform mid-press. */
-  .top-link.is-visible-mobile:active {
-    transform: translateY(0) scale(0.9);
-    transition: transform 0.1s ease;
-  }
-
-  /* Replace the grey tap-flash with our own scale cue. */
-  .top-link {
-    -webkit-tap-highlight-color: transparent;
-  }
-}
-
-/* ============================================================
-   Reduced motion: fade only — no rise, no spring, no squash.
-   ============================================================ */
-@media (max-width: 1023px) and (prefers-reduced-motion: reduce) {
-  .top-link {
-    transform: none !important;
-    transition: opacity 0.2s ease, visibility 0.2s ease !important;
-  }
-  .top-link.is-visible-mobile,
-  .top-link.is-visible-mobile:active {
-    transform: none !important;
+    display: none !important;
   }
 }

--- a/layouts/partials/seo.html
+++ b/layouts/partials/seo.html
@@ -48,7 +48,10 @@
 {{- $defaultOgImage := index (site.Params.images | default (slice "/assets/og-image.png")) 0 -}}
 {{- $sectionOgImage := index $sectionDefault .Section | default $defaultOgImage -}}
 {{- $ogImage := $sectionOgImage -}}
-{{- with .Params.cover.image -}}{{- $ogImage = . -}}{{- end -}}
+{{- /* Social/search crawlers (Bing thumbnails, WeChat/X/LinkedIn/FB cards) reject
+       SVG as a preview image — they need a raster 1200×630. Only override with the
+       cover when it's NOT an SVG; otherwise keep the section/default PNG. */ -}}
+{{- with .Params.cover.image -}}{{- if not (strings.HasSuffix (lower .) ".svg") -}}{{- $ogImage = . -}}{{- end -}}{{- end -}}
 <meta property="og:image" content="{{ $ogImage | absURL }}" />
 <meta property="og:image:alt" content="{{ with .Params.cover.alt }}{{ . }}{{ else }}{{ .Title }}{{ end }}" />
 <meta property="og:image:width" content="1200" />


### PR DESCRIPTION
## 概述

本分支聚合三项改进,核心是**移动端文章页的悬浮控件精简**,附带此前的 ZH 标题字体 LCP 优化与 OG 图修复。

## 主要改动:移动端悬浮控件精简 (`11cc97d`)

### 问题
手机端文章页右下角**堆叠了两个常驻圆形浮层**,压在正文之上:
- 深色**返回顶部**球 (`.top-link`)
- 实心暗红的**目录/AI/分享工具 FAB** (`.article-fab`)

两个控件在同一角落上下堆叠,是移动端阅读最该避免的 chrome 干扰——读者应该看到文章,而不是控件。

### 方案:收敛成一个几乎隐形的极简控件
- **手机端 (`≤1023px`) 彻底移除返回顶部球**。它是多余的第二浮层;FAB 抽屉的「目录」tab 已能跳转到任意标题(含顶部)。**桌面端返回顶部不受影响。**
- **重塑工具 FAB,让它隐入正文**:
  - 48 → 40px
  - `color-mix` 半透明 accent(静止 opacity `.62`)+ 轻背景模糊 + 柔和浅阴影,取代原先的实心色块 + 重阴影
  - 仅在 `:active` / `:focus-visible` 时升为实心满色——静止是暗示,触碰即到位
  - 下移到底角(不再有东西堆在下面)

**底部抽屉功能不变**——目录 / AI / 分享(系列文章还有「系列」)全部照常可达。

### 验证
- 手机端 390px:返回顶部球消失、FAB 变淡变小、点开抽屉四功能齐全 ✓
- 桌面端 1440px:返回顶部 + 右侧栏照常工作 ✓
- 0 控制台报错

改动仅两文件:`assets/css/extended/article-bottom-sheet.css`、`assets/css/extended/zzz-mobile-back-to-top.css`。

## 附带改动(此前提交)
- `602c731` fix(seo): 封面为 SVG 时保留位图 og:image
- `5daa630` perf(fonts): ZH 文章标题用本地衬线字体绘制以解除 LCP 阻塞

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined the mobile floating action button with a smaller, translucent appearance that becomes prominent when focused or activated.
  - Removed the mobile back-to-top control.
  - Improved Chinese typography by prioritizing locally available serif fonts for faster text rendering and more consistent display.

- **Bug Fixes**
  - Social and search previews now avoid using SVG cover images, falling back to supported preview images when necessary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->