### PR TITLE
fix(mobile): hide the article FAB once the reader reaches the comments

### DIFF
--- a/static/js/article-bottom-sheet.js
+++ b/static/js/article-bottom-sheet.js
@@ -49,7 +49,46 @@
     window.addEventListener('scroll', onScroll, { passive: true });
     onScroll();
 
+    // FAB auto-fade once the reader reaches the end-of-article zone.
+    // Past the article body — the comments, related posts and footer —
+    // the Contents / AI tools no longer serve the read, so the FAB
+    // should get out of the way rather than sit over the discussion.
+    initEndZoneFade();
+
     initMobileAi();
+  }
+
+  /* ── Hide the FAB in the end-of-article zone ──────────────────
+     `fromBottom < 80` alone kept the FAB visible all through a tall
+     comments iframe (utterances) because real page-bottom was still
+     far below. Watch the first end-zone block instead — comments, or
+     failing that related-posts / post-footer — and fade the FAB the
+     moment it scrolls into view. Purely additive: `endZoneVisible`
+     only ever forces the hide; onScroll still owns the top/bottom
+     fades. No IntersectionObserver (very old browser) → no-op, and the
+     scroll-based fade still applies. */
+  var endZoneVisible = false;
+
+  function initEndZoneFade() {
+    if (!('IntersectionObserver' in window)) return;
+    var target =
+      document.querySelector('.post-comments') ||
+      document.querySelector('.related-posts') ||
+      document.querySelector('.post-footer');
+    if (!target) return;
+
+    var io = new IntersectionObserver(function (entries) {
+      endZoneVisible = entries[0].isIntersecting;
+      onScroll();
+    }, {
+      // Fade as soon as the end zone's top edge crosses into the lower
+      // viewport — the moment the reader is done with the body and the
+      // comments start coming up, the FAB clears out. No negative
+      // bottom margin (that delayed the trigger until the block was
+      // well up the screen); intersecting-at-all is the signal.
+      threshold: 0,
+    });
+    io.observe(target);
   }
 
   /* ── Finger-following drag-to-close ───────────────────────────
@@ -445,7 +484,10 @@
     var docH      = document.documentElement.scrollHeight;
     var viewH     = window.innerHeight;
     var fromBottom = docH - scrollY - viewH;
-    var hide = scrollY < FAB_HIDE_SCROLL || fromBottom < FAB_HIDE_BOTTOM;
+    var hide =
+      scrollY < FAB_HIDE_SCROLL ||
+      fromBottom < FAB_HIDE_BOTTOM ||
+      endZoneVisible;            // reached comments / related / footer
     fab.classList.toggle('article-fab--hidden', hide);
   }
 


### PR DESCRIPTION
The tools FAB stayed parked over the bottom-right corner all through the comments section and related-posts — exactly the end-of-article zone where Contents / AI no longer serve the read. The old auto-fade only triggered within 80px of the true page bottom, and a tall utterances comments iframe pushes that bottom far below the fold, so the FAB never faded while sitting over the discussion.

Watch the first end-of-article block with an IntersectionObserver (.post-comments, falling back to .related-posts / .post-footer) and fade the FAB the moment that block scrolls into view. Additive: the new `endZoneVisible` flag only ever forces the hide; onScroll still owns the existing top/near-bottom fades. No IntersectionObserver → no-op, scroll fade still applies.

Verified on a 390px viewport by stepping through the scroll: FAB shows across the article body, hides at top, and now hides the instant the comments enter view and stays hidden through related-posts / footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The mobile article floating action button now automatically hides when readers reach the comments, related posts, or footer.
  * Improved behavior near the end of articles by reducing overlap with page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->