### PR TITLE
fix(e2e): green the ZH suite — drop missing cover image + refresh dark-accent expectations

### DIFF
--- a/content/zh/engineering/posts/use-go-tools-dlv.md
+++ b/content/zh/engineering/posts/use-go-tools-dlv.md
@@ -2,9 +2,6 @@
 title: 'Go 调试测试以及调试工具 dlv 学习'
 description: '本文深入介绍 Go 语言的调试过程，测试方法以及如何使用调试工具 dlv 来优化代码。'
 ShowRssButtonInSectionTermList: true
-cover:
-    image: 'images/blog/go-debugging.png'  # 假设您有这张图片，如无请更换
-    caption: 'Go 调试和 dlv 工具学习'
 date: '2023-06-19T16:38:39+08:00'
 draft: false
 showtoc: true

--- a/tests/e2e/us032-dark-mode.spec.ts
+++ b/tests/e2e/us032-dark-mode.spec.ts
@@ -37,7 +37,7 @@ test('EN light: --color-accent is dark olive (not dark override)', async ({ page
   );
   // EN light accent should be ~#2e352e
   expect(accent).not.toBe('');
-  expect(accent).not.toContain('ff3b3b'); // not ZH dark red
+  expect(accent).not.toContain('ff6b6b'); // not ZH dark red
   await screenshot(page, 'en-light-desktop');
 });
 
@@ -143,7 +143,7 @@ test('ZH dark: --color-ink is warm white (#f5f3ee)', async ({ page }) => {
   expect(ink).toMatch(/#?f5f3ee|245,243,238/i);
 });
 
-test('ZH dark: --color-accent is vivid red (#ff3b3b)', async ({ page }) => {
+test('ZH dark: --color-accent is red (#ff6b6b)', async ({ page }) => {
   await page.setViewportSize({ width: 1680, height: 1050 });
   await page.goto(ZH_URL);
   await page.waitForLoadState('networkidle');
@@ -152,7 +152,7 @@ test('ZH dark: --color-accent is vivid red (#ff3b3b)', async ({ page }) => {
   const accent = await page.evaluate(() =>
     getComputedStyle(document.body).getPropertyValue('--color-accent').trim()
   );
-  expect(accent).toMatch(/#?ff3b3b|255,59,59/i);
+  expect(accent).toMatch(/#?ff6b6b|255,107,107/i);
 });
 
 test('ZH dark: full page screenshot', async ({ page }) => {
@@ -190,7 +190,7 @@ test('EN: dark class toggle changes --color-paper token', async ({ page }) => {
 
 // ── US-032-06: ZH dark — accent for h2/drop-cap reflects token ───
 
-test('ZH dark: h2 border-left color reflects --color-accent (#ff3b3b)', async ({ page }) => {
+test('ZH dark: h2 border-left color reflects --color-accent (#ff6b6b)', async ({ page }) => {
   await page.setViewportSize({ width: 1680, height: 1050 });
   await page.goto(ZH_URL);
   await page.waitForLoadState('networkidle');
@@ -201,8 +201,8 @@ test('ZH dark: h2 border-left color reflects --color-accent (#ff3b3b)', async ({
     if (!h2) return '';
     return getComputedStyle(h2).borderLeftColor;
   });
-  // rgb(255,59,59) = #ff3b3b
-  expect(h2Color).toMatch(/255,\s*59,\s*59/);
+  // rgb(255,107,107) = #ff6b6b
+  expect(h2Color).toMatch(/255,\s*107,\s*107/);
 });
 
 // ── US-032-07: 0 console errors ──────────────────────────────────

--- a/tests/e2e/visual/aesthetic-agent.spec.ts
+++ b/tests/e2e/visual/aesthetic-agent.spec.ts
@@ -104,7 +104,7 @@ test('en-dark-desktop: EN dark mode applies correct tokens', async ({ page }) =>
   const accent = await page.evaluate(() =>
     getComputedStyle(document.body).getPropertyValue('--color-accent').trim()
   );
-  expect(accent).not.toContain('ff3b3b');
+  expect(accent).not.toContain('ff6b6b');
 
   await takeScreenshot(page, 'en-dark-desktop');
 });
@@ -139,7 +139,7 @@ test('zh-dark-desktop: ZH dark mode applies correct tokens', async ({ page }) =>
   const accent = await page.evaluate(() =>
     getComputedStyle(document.body).getPropertyValue('--color-accent').trim()
   );
-  expect(accent.toLowerCase()).toContain('ff3b3b');
+  expect(accent.toLowerCase()).toContain('ff6b6b');
 
   await takeScreenshot(page, 'zh-dark-desktop');
 });


### PR DESCRIPTION
## What & why

The ZH end-to-end suite has been red on `main` from two pre-existing issues unrelated to any single feature (they surfaced while watching #219). This PR fixes both so the suite goes green.

## Changes

1. **Missing cover image (404 → console errors).** `content/zh/engineering/posts/use-go-tools-dlv.md` referenced a cover image `images/blog/go-debugging.png` that never existed in the repo — its own frontmatter comment flagged it as a placeholder (`# 假设您有这张图片，如无请更换`). The resulting 404 tripped every "0 console errors on ZH" assertion (`us027`–`us031`, `us032`). Removed the broken `cover` block; the EN counterpart of this article has no cover either.

2. **Stale dark-accent expectation.** The dark-mode `--color-accent` token was rethemed to `#ff6b6b` (softer coral) in the editorial retheme, but the tests still asserted the old `#ff3b3b`. Updated the ZH-dark expectations — and the "not ZH red" guards — to the current design token:
   - `tests/e2e/us032-dark-mode.spec.ts`: `#ff6b6b` / `rgb(255,107,107)`
   - `tests/e2e/visual/aesthetic-agent.spec.ts`: `ff6b6b`

## Verification

Local Hugo build + Playwright against the ZH article:

- ✅ `go-debugging.png` 404 is gone (no real console errors remain)
- ✅ `--color-accent` in ZH dark resolves to `#ff6b6b`
- ✅ `.post-content h2` border-left resolves to `rgb(255, 107, 107)`

These map 1:1 to the updated assertions, so `us027`–`us032` and the `aesthetic-agent` ZH-dark checks should pass.

## Note

Test expectations were updated to match an **intentional** design-token change (the retheme), not to paper over a regression — `#ff6b6b` is the value shipped in `tokens.css` on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016xAzkhtHe3q6LyDe3DRKWB

---
_Generated by [Claude Code](https://claude.ai/code/session_016xAzkhtHe3q6LyDe3DRKWB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Chinese dark-mode accent color to the new `#ff6b6b` value, including heading borders and visual styling checks.
  * Corrected dark-mode visual validation to distinguish English and Chinese accent colors.

* **Documentation**
  * Removed the cover image configuration from a Chinese engineering article.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->