### PR TITLE
refactor(copy): strip filler words and modal particles from UI copy

### DIFF
--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -8,7 +8,7 @@ hero:
     - "OPEN SOURCE"
     - "DIGITAL NOMAD"
   bioEn: "I build <strong>AI products</strong> and contribute to <strong>open source</strong> while wandering the world. Capturing raw signals from each day — code, thoughts, places — and compiling them into something durable."
-  bioZh: "构建 <strong>AI 产品</strong>，贡献<strong>开源代码</strong>，在世界的褶皱里慢慢走。每天捕捉那些原始信号——代码、念头、地方——然后让它们结晶成一些可以保留下来的东西。"
+  bioZh: "构建 <strong>AI 产品</strong>，贡献<strong>开源代码</strong>，在世界的褶皱里慢慢走。每天捕捉原始信号——代码、念头、地方——让它们结晶成能留下来的东西。"
   footerBioEn: "Xinwei Xiong — AI builder, open source contributor and digital nomad. Kubernetes, Go, AI agents & travel."
   footerBioZh: "熊鑫伟 — AI 构建者、开源贡献者、数字游民。在中国与世界之间慢慢走的探索者。"
   siteVersion: "v3.0"

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -7,7 +7,7 @@
         <div class="not-found-code">404</div>
         {{- $isZh := eq site.Language.Lang "zh" }}
         <h1 class="not-found-title">{{ if $isZh }}页面未找到{{ else }}Page Not Found{{ end }}</h1>
-        <p class="not-found-desc">{{ if $isZh }}这个页面好像去冒险了，找不回来了。让我们重新出发。{{ else }}Looks like this page went exploring without a map. Let's get you back on track.{{ end }}</p>
+        <p class="not-found-desc">{{ if $isZh }}这个页面去冒险了，一时找不回来。重新出发。{{ else }}Looks like this page went exploring without a map. Let's get you back on track.{{ end }}</p>
         <div class="not-found-actions">
             <a href="{{ "/" | relLangURL }}" class="not-found-btn not-found-btn--primary">← {{ if $isZh }}返回主页{{ else }}Go Home{{ end }}</a>
             <a href="{{ "/articles/" | relLangURL }}" class="not-found-btn not-found-btn--secondary">{{ if $isZh }}浏览所有文章{{ else }}Browse All Articles{{ end }}</a>

--- a/layouts/page/travel.html
+++ b/layouts/page/travel.html
@@ -130,7 +130,7 @@
       <span class="tw-eyebrow">QUEST&nbsp;LOG</span>
       <h2 class="tw-section-title">{{ if $isZh }}已解锁的地图{{ else }}Unlocked Maps{{ end }}</h2>
       <p class="tw-section-desc">
-        {{- if $isZh }}每到一个地区，就多一片会自己发光的地图。点开一条存档，回到那个坐标。
+        {{- if $isZh }}每到一个地区，地图就多亮一块。点开存档，回到那个坐标。
         {{- else }}Every region visited lights up another patch of the map. Open a save to return to those coordinates.
         {{- end }}
       </p>
@@ -243,12 +243,12 @@
       <div class="tw-code__card tw-reveal">
         <span class="tw-code__num">01</span>
         <h3>{{ if $isZh }}没有 NPC{{ else }}No NPCs{{ end }}</h3>
-        <p>{{ if $isZh }}每一个擦肩而过的人都是真实玩家，各有自己的主线。停下来说话，支线就展开了。{{ else }}Everyone you pass is a real player running a main quest of their own. Stop and talk — a side quest unfolds.{{ end }}</p>
+        <p>{{ if $isZh }}每一个擦肩而过的人都是真实玩家，各有主线。停下来说话，支线就展开。{{ else }}Everyone you pass is a real player running a main quest of their own. Stop and talk — a side quest unfolds.{{ end }}</p>
       </div>
       <div class="tw-code__card tw-reveal">
         <span class="tw-code__num">02</span>
         <h3>{{ if $isZh }}不赶主线{{ else }}Never Speedrun{{ end }}</h3>
-        <p>{{ if $isZh }}最好的剧情都藏在支线里。驻留、绕路、坐慢车，让每张地图以自己的节奏展开。{{ else }}The best storylines hide in side quests. Stay longer, take detours, ride the slow train.{{ end }}</p>
+        <p>{{ if $isZh }}最好的剧情藏在支线里。驻留、绕路、坐慢车，让每张地图慢慢展开。{{ else }}The best storylines hide in side quests. Stay longer, take detours, ride the slow train.{{ end }}</p>
       </div>
       <div class="tw-code__card tw-reveal">
         <span class="tw-code__num">03</span>


### PR DESCRIPTION
## 目标

对博客的 UI 文案（模板 / 数据文件里的"博客自己的声音"）逐句做**删除测试**：删掉某个语气词或抒情虚词后，如果这句话的信息量不变，就删掉它。保留 travel / growth 等 section 有意设计的游戏 / 花园隐喻词汇，只精简其中的填充词。范围限定在 UI chrome 文案，不动文章正文。

## 改动

**`layouts/page/travel.html`**（用户举例的重灾区）
- `每到一个地区，就多一片会自己发光的地图` → `每到一个地区，地图就多亮一块`
- `各有自己的主线。……支线就展开了` → `各有主线。……支线就展开`
- `让每张地图以自己的节奏展开` → `让每张地图慢慢展开`
- 顺带删掉冗余的 `一条 / 一片 / 了`

**`data/homepage.yml`** — 首页 bio
- `捕捉那些原始信号……然后让它们结晶成一些可以保留下来的东西` → `捕捉原始信号……让它们结晶成能留下来的东西`（删 `那些 / 然后 / 一些 / 可以…下来`）

**`layouts/404.html`**
- `这个页面好像去冒险了，找不回来了。让我们重新出发。` → `这个页面去冒险了，一时找不回来。重新出发。`（删 `好像 / 让我们` 的软化 / 填充）

## 说明

我把整个 `layouts/`、`data/`、`i18n/` 都扫了一遍找语气词和修饰性虚词；经过近期改版，站内绝大多数 UI 文案已经比较紧凑，填充词主要集中在上面这几处（以你点名的 travel 页为主）。`index_profile.html` / `home-info.html` 是未被引用的历史模板，未改动。

## 验证

用固定版本 `hugo 0.145.0 extended`（`--gc --minify`，production 环境）完整构建，中英双语共 1100+ 页，exit 0 无报错 / 警告；并核对了 `public/` 里生成的 HTML —— 精简后的文案已正确渲染，旧填充词在输出中已完全消失。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019tCLxcHrjUq2AFPMqs1fFB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Copy Updates**
  * Refined Chinese homepage hero biography text for a shorter, smoother reading experience.
  * Updated Chinese 404 page messaging.
  * Refined Chinese travel page descriptions for the “QUEST LOG” and “PLAYER’S CODE” sections.
  * English content and page structure remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->