### PR TITLE
feat(travel): expand book shelf with Tibet + Wudai; drop old nsddd.top links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 > [!NOTE]
 > + [关于我](https://cubxxw.com/zh/about/)
-> + [一些碎片的思考笔记](https://diary.nsddd.top/flomo-original/)
+> + [一些碎片的思考笔记](https://cubxxw.com/zh/growth/)
 > + [跟着我看我环游世界旅居的笔记](https://www.polarsteps.com/cubxxw)
 
 

--- a/data/travel.yml
+++ b/data/travel.yml
@@ -84,6 +84,44 @@ books:
       - What sense of time arises before stone swallowed by tree roots?
       - What history is worth knowing before visiting Angkor?
 
+  - title_zh: 西藏
+    title_en: Tibet
+    author_zh: 熊鑫伟 · 自著
+    author_en: Xinwei Xiong · self-written
+    slot_zh: 自制装备 · 卷三
+    slot_en: Crafted Gear · Vol. III
+    note_zh: 海拔 3650 米的拉萨——被高原强制降速的一段路，看云、看人、看信仰怎么落进日子里。
+    note_en: Lhasa at 3,650 m — a stretch of road the plateau forces you to slow down on, watching clouds, people and faith settle into everyday life.
+    url: https://tibet.cubxxw.com/
+    own: true
+    ai_prompts_zh:
+      - 高原反应之外，西藏最让作者「降速」的是什么？
+      - 在拉萨慢下来的这些天，作者看见了怎样的信仰与日常？
+      - 第一次进藏，作者会给什么样的节奏建议？
+    ai_prompts_en:
+      - Beyond altitude sickness, what really made the author slow down in Tibet?
+      - What faith and daily life did the author notice in those slow Lhasa days?
+      - For a first trip to Tibet, what pace would the author suggest?
+
+  - title_zh: 乱世为龙
+    title_en: Dragon in a Broken Age
+    author_zh: 熊鑫伟 · 自著
+    author_en: Xinwei Xiong · self-written
+    slot_zh: 自制装备 · 卷四
+    slot_en: Crafted Gear · Vol. IV
+    note_zh: 一部写后周太祖郭威的历史长篇——从颈刺飞雀的潞州孤儿，到碎玉罢租、薄葬嵩陵的开国天子。史实为骨，文学为肉。
+    note_en: A historical novel of Guo Wei, founding emperor of Later Zhou — from a tattooed orphan in Luzhou to a ruler who smashed the palace jade and chose a pauper's burial. History for the bones, fiction for the flesh.
+    url: https://wudai.cubxxw.com/
+    own: true
+    ai_prompts_zh:
+      - 「天子，兵强马壮者为之」——郭威是怎么在这套乱世规则里活下来的？
+      - 登基后先砸碎宫里的金玉，郭威想改写的到底是什么？
+      - 五代十国为什么是「最黑暗也最赤裸」的五十三年？
+    ai_prompts_en:
+      - How did Guo Wei survive an age where "the throne goes to whoever has the strongest army"?
+      - Why did Guo Wei smash the palace jade the moment he took the throne?
+      - What made the Five Dynasties the most brutal, most naked fifty-three years in Chinese history?
+
   - title_zh: 在路上
     title_en: On the Road
     author_zh: 杰克·凯鲁亚克

--- a/layouts/page/travel.html
+++ b/layouts/page/travel.html
@@ -232,8 +232,8 @@
       {{- end }}
     </div>
     <p class="tw-shelf__coda tw-reveal">
-      {{- if $isZh }}钤朱印「著」的两卷，是我自己在路上写下的。点任意一本书上的「问 AI」，可以就这本书追问下去。
-      {{- else }}The two spines bearing the vermilion seal are the volumes I wrote on the road. Hit "Ask AI" on any book to keep digging into it.
+      {{- if $isZh }}钤朱印「著」的四卷都是我自己写的——越南、吴哥窟、西藏三本旅行记，和一部写五代郭威的历史长篇《乱世为龙》。点任意一本书上的「问 AI」，可以就这本书追问下去。
+      {{- else }}The four spines bearing the vermilion seal are all mine — travelogues of Vietnam, Angkor and Tibet, plus Dragon in a Broken Age, a historical novel of Guo Wei in the Five Dynasties. Hit "Ask AI" on any book to keep digging into it.
       {{- end }}
     </p>
 

--- a/layouts/partials/seo/structured-data.html
+++ b/layouts/partials/seo/structured-data.html
@@ -172,7 +172,6 @@
   "email": "mailto:3293172751nss@gmail.com",
   "sameAs": [
     "https://cubxxw.com",
-    "https://nsddd.top",
     "https://github.com/cubxxw",
     "https://x.com/cubxxw",
     "https://www.linkedin.com/in/cubxxw",

--- a/static/README.md
+++ b/static/README.md
@@ -13,7 +13,7 @@
 
 > [!NOTE]
 > + [关于我](https://cubxxw.com/zh/about/)
-> + [一些碎片的思考笔记](https://diary.nsddd.top/flomo-original/)
+> + [一些碎片的思考笔记](https://cubxxw.com/zh/growth/)
 > + [跟着我看我环游世界旅居的笔记](https://www.polarsteps.com/cubxxw)
 
 


### PR DESCRIPTION
## What & why

Optimizes the **"Books in the Pack" (行囊里的书)** shelf on the travel page and finishes clearing the old `nsddd.top` main-site links, moving them to the migrated `cubxxw.com` domain.

The shelf previously carried two self-written volumes (Vietnam, Angkor). This adds the remaining two microsites the author supplied, so all four self-authored works are on the shelf and on `cubxxw.com`.

## Changes

**Travel book shelf** — `data/travel.yml`
- **西藏 / Tibet** (卷三, `tibet.cubxxw.com/`) — a Lhasa travelogue.
- **乱世为龙 / Dragon in a Broken Age** (卷四, `wudai.cubxxw.com/`) — a self-written **historical novel** of Guo Wei (郭威), founding emperor of Later Zhou, set in the 五代十国 / Five Dynasties (hence *wudai*). Not a travelogue — the note and prompts reflect that.
- Each entry has a bilingual `note` plus three per-language "Ask AI" prompts, matching the existing schema.
- There are now **four** self-written volumes: Vietnam, Angkor, Tibet, 乱世为龙.

**Shelf coda** — `layouts/page/travel.html`
- Updated from *"the two spines … written on the road"* to **four**, and reworded to cover three travelogues plus the historical novel (which wasn't written "on the road").

**Old-domain cleanup (`nsddd.top` → `cubxxw.com`, main-site links only)**
- `layouts/partials/seo/structured-data.html` — dropped the stale `https://nsddd.top` entry from the Person `sameAs` list (`cubxxw.com` is already listed).
- `README.md`, `static/README.md` — repointed the "碎片思考笔记" link from `diary.nsddd.top/flomo-original/` to `cubxxw.com/zh/growth/`, matching the existing thought-notes entries.

**Intentionally kept** (out of scope per the agreed narrow replacement):
- `sm.nsddd.top` image CDN (~70 article images) and `docker/go.nsddd.top` doc sites — `cubxxw.com` doesn't host those, so swapping would 404.
- The GEO/SEO case-study articles that reference `nsddd.top` as the **subject** of the migration narrative.
- The RedNote handle `nsddd_top` (a username, not a link).

## Verification

Full **Hugo 0.147.0-extended** production build passes (exit 0, no errors). Both travel pages render four seal-stamped (`著`) books linking to `tibet/angkor/vietnam/wudai.cubxxw.com`, the coda shows "四卷 / four spines", and the Person JSON-LD is valid with `nsddd.top` removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HLMf6xGPeCwfdxzbUBoE9Y

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLMf6xGPeCwfdxzbUBoE9Y)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two travel books—*Tibet* and *Dragon in a Broken Age*—with bilingual AI prompts.
  * Updated the travel page to showcase four featured volumes and their expanded descriptions.

* **Content Updates**
  * Redirected fragmentary thoughts links to the site’s Chinese growth section.
  * Updated author profile metadata and removed an outdated profile link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->