### PR TITLE
style(columns): 专栏落地页强化设计感与呼吸感

### DIFF
--- a/assets/css/extended/columns.css
+++ b/assets/css/extended/columns.css
@@ -828,10 +828,11 @@ a.column-outro__title:focus-visible {
 }
 
 /* ── Reduced motion ──────────────────────────────────────────
-   Remove the hover arrow travel and row lean, and skip the load
-   entrance; opacity/colour hover cues remain. */
+   Remove the hover arrow travel and row lean; opacity/colour hover
+   cues remain. (The load entrance needs no reset here — it is only
+   declared under prefers-reduced-motion: no-preference, so it never
+   applies in the first place.) */
 @media (prefers-reduced-motion: reduce) {
-  .column-entry { animation: none; }
   .column-entry__link:hover .column-entry__body,
   .column-entry__link:focus-visible .column-entry__body { transform: none; }
   .column-entry__link:hover .column-entry__arrow,

--- a/assets/css/extended/columns.css
+++ b/assets/css/extended/columns.css
@@ -153,6 +153,55 @@
   font-style: italic;
 }
 
+/* ── Standfirst structured list — the column's argument as strata ──
+   Two columns open on a list that IS the thesis: the super-individual
+   "四层" stack and the info→creation "四道工序". Lift such a list out of
+   default body-bullets into ruled editorial bands — an accent folio-tick
+   clamped to each stratum, the leading label carried in the accent ink,
+   roomier leading. Scoped to lists inside the standfirst, so prose
+   paragraphs are untouched; works for any item count and any column. */
+.column-intro__body ul,
+.column-intro__body ol {
+  list-style: none;
+  margin: 2rem 0 1.9rem;
+  padding: 0;
+}
+.column-intro__body li {
+  position: relative;
+  margin: 0;
+  padding: 1.05rem 0 1.05rem 1.75rem;
+  border-top: 1px solid var(--color-rule, rgba(53, 0, 3, 0.1));
+  line-height: 1.85;
+}
+.column-intro__body li:last-child {
+  border-bottom: 1px solid var(--color-rule, rgba(53, 0, 3, 0.1));
+}
+:lang(zh) .column-intro__body li {
+  line-height: 1.95;
+  letter-spacing: 0.015em;
+}
+/* Folio tick — a short accent rule clamped to each stratum's first line,
+   echoing the eyebrow rules and the folio nodes below. */
+.column-intro__body li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 1.6rem;
+  width: 0.72rem;
+  height: 2px;
+  border-radius: 1px;
+  background: var(--color-accent, #862122);
+  opacity: 0.85;
+}
+:lang(zh) .column-intro__body li::before {
+  top: 1.72rem;
+}
+/* The leading label reads as the term being defined. */
+.column-intro__body li > strong:first-child {
+  color: var(--color-accent, #862122);
+  font-weight: 600;
+}
+
 /* ── TOC heading ─────────────────────────────────────────────────── */
 
 .column-toc {
@@ -305,6 +354,13 @@
   flex-direction: column;
   gap: 0.5rem;
   min-width: 0;
+  transition: transform var(--dur-hover, 200ms) var(--ease-out, ease);
+}
+/* The row leans a hair toward the reader on hover — pairs with the folio
+   node lift and the arrow travel so the whole entry reads as one target. */
+.column-entry__link:hover .column-entry__body,
+.column-entry__link:focus-visible .column-entry__body {
+  transform: translateX(4px);
 }
 .column-entry__title {
   font-family: var(--font-display, 'Fraunces', 'Georgia', serif);
@@ -417,6 +473,43 @@
   letter-spacing: 0.3em;
   text-transform: uppercase;
   color: var(--color-ink-muted, #5e5e63);
+}
+/* Closing affordance — a quiet way back to the shelf of columns */
+.column-footer__back {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 1.6rem;
+  padding: 0.4rem 0.2rem;
+  font-family: var(--font-mono, 'JetBrains Mono', monospace);
+  font-size: 0.66rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: var(--color-ink-muted, #5e5e63);
+  border-radius: 6px;
+  transition: color var(--dur-hover, 200ms) ease;
+}
+.column-footer__back:hover,
+.column-footer__back:focus-visible {
+  color: var(--color-accent, #862122);
+}
+.column-footer__back:focus-visible {
+  outline: 2px solid var(--color-accent, #862122);
+  outline-offset: 3px;
+}
+.column-footer__back-arrow {
+  width: 15px;
+  height: 15px;
+  transition: transform var(--dur-hover, 200ms) var(--ease-out, ease);
+}
+.column-footer__back:hover .column-footer__back-arrow,
+.column-footer__back:focus-visible .column-footer__back-arrow {
+  transform: translateX(-3px);
+}
+@media (prefers-reduced-motion: reduce) {
+  .column-footer__back:hover .column-footer__back-arrow,
+  .column-footer__back:focus-visible .column-footer__back-arrow { transform: none; }
 }
 
 /* ── Mobile ──────────────────────────────────────────────────────── */
@@ -705,9 +798,42 @@ a.column-outro__title:focus-visible {
   }
 }
 
+/* ── Load entrance — the reading path draws itself in ────────────
+   Each entry (folio node + text + its spine segment) fades up in sequence,
+   so the 01 → NN path assembles top-to-bottom rather than snapping in flat.
+   Purely decorative and non-blocking: `both` holds the settled state, the
+   masthead/intro above are never animated (no LCP impact), and the whole
+   effect is gated off under reduced-motion. */
+@media (prefers-reduced-motion: no-preference) {
+  .column-entry {
+    animation: column-entry-in 620ms var(--ease-out, ease) both;
+  }
+  .column-entry:nth-child(1) { animation-delay: 40ms; }
+  .column-entry:nth-child(2) { animation-delay: 110ms; }
+  .column-entry:nth-child(3) { animation-delay: 180ms; }
+  .column-entry:nth-child(4) { animation-delay: 250ms; }
+  .column-entry:nth-child(5) { animation-delay: 320ms; }
+  .column-entry:nth-child(6) { animation-delay: 390ms; }
+  .column-entry:nth-child(n + 7) { animation-delay: 450ms; }
+}
+@keyframes column-entry-in {
+  from {
+    opacity: 0;
+    transform: translateY(14px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* ── Reduced motion ──────────────────────────────────────────
-   Remove the hover arrow travel; opacity/colour hover cues remain. */
+   Remove the hover arrow travel and row lean, and skip the load
+   entrance; opacity/colour hover cues remain. */
 @media (prefers-reduced-motion: reduce) {
+  .column-entry { animation: none; }
+  .column-entry__link:hover .column-entry__body,
+  .column-entry__link:focus-visible .column-entry__body { transform: none; }
   .column-entry__link:hover .column-entry__arrow,
   .column-entry__link:focus-visible .column-entry__arrow { transform: none; }
   .column-outro__next:hover .column-outro__next-arrow,

--- a/layouts/columns/term.html
+++ b/layouts/columns/term.html
@@ -108,6 +108,13 @@
     <p class="column-footer__note">
       {{- if $isZh -}}— 完 —{{- else -}}— End —{{- end -}}
     </p>
+    <a class="column-footer__back" href="{{ "columns/" | relLangURL }}">
+      <svg class="column-footer__back-arrow" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <line x1="19" y1="12" x2="5" y2="12"/>
+        <polyline points="12 19 5 12 12 5"/>
+      </svg>
+      <span>{{ if $isZh }}全部专栏{{ else }}All columns{{ end }}</span>
+    </a>
   </footer>
 
 </article>


### PR DESCRIPTION
## 背景

针对专栏落地页 `/zh/columns/super-individual-stack/` 做一轮设计打磨——设计感、呼吸感、观感。全部改动作用于共享的专栏模板与样式，同一套视觉语言惠及所有专栏落地页与专栏索引页,并在桌面/移动、明/暗四种组合下反复截图验证,无回归。

## 改动

**1. 标准首(standfirst)结构化列表 → 编辑式「分层带」(核心)**
- 「超级个体装备栈」的四层、「从信息到创作」的四道工序,都是以列表承载论点主干。把它从默认圆点升级为贯通细分割线的 ruled bands:每条一个 accent 折页刻度、首个 `<strong>` 标签用 accent 墨色承载「术语」,行距更从容。
- 仅作用于 `.column-intro__body` 内的 `ul/ol`,正文段落与其他无列表的专栏(如 Agent 工程)完全不受影响。

**2. 呼吸感**
- 分层带内外留白加大,段落到目录的阅读节奏更舒展。

**3. 生命力(可访问性优先)**
- 目录条目加入错峰载入入场:01 → NN 自上而下逐条浮现,连载脊线随之描绘。
- hover 时整行朝读者轻移,与折页节点抬升、箭头位移共同构成同一个可点区反馈。
- 以上动效全部在 `prefers-reduced-motion: reduce` 下关闭。

**4. 收束**
- 页脚在「— 完 —」下新增「全部专栏 / All columns」返回入口(带 `focus-visible` 焦点态),读完一栏可平滑回到专栏架。

## 验证

- 用 pin 住的 Hugo 0.145.0 extended 启动 dev server,对 ZH 落地页、`info-to-creation`、专栏索引页在桌面/移动 × 明/暗逐一截图核对。
- `hugo --gc --minify` 生产构建通过,无 error/warning。

## 涉及文件

- `assets/css/extended/columns.css`
- `layouts/columns/term.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NMmGZmRm4kNCiPeeDCVmFf

---
_Generated by [Claude Code](https://claude.ai/code/session_01NMmGZmRm4kNCiPeeDCVmFf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a localized “Back to all columns” link with an animated arrow.
  - Added structured styling for standfirst lists, including accent borders, labels, and folio markers.
  - Added progressive entrance animations for reading path entries.

- **Enhancements**
  - Added interactive hover and focus movement effects for reading path entries.
  - Improved keyboard focus styling and support for reduced-motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->