### PR TITLE
feat(post-nav): 直觉化的上/下一篇方向 + 更优雅的推荐卡动效

### DIFF
--- a/assets/css/extended/micro-interactions.css
+++ b/assets/css/extended/micro-interactions.css
@@ -269,20 +269,11 @@ button:focus-visible,
   z-index: 1;
 }
 
-/* ---------- Prev / next pagination: desktop hover lift ---------- */
-/* Pairs the existing :active press with a gentle hover cue so the
-   prev/next blocks feel as tactile on a trackpad as a card does. */
-.paginav a {
-  transition:
-    transform 0.18s cubic-bezier(0.22, 0.61, 0.36, 1),
-    box-shadow 0.18s ease,
-    background-color 0.18s ease;
-}
-@media (hover: hover) and (pointer: fine) {
-  .paginav .prev:hover { transform: translateX(-3px); }
-  .paginav .next:hover { transform: translateX(3px); }
-}
-.paginav a:active { transform: scale(0.985); }
+/* ---------- Prev / next pagination ----------
+   The whole hover/press/lift treatment for `.paginav a` lives in
+   post-footer.css (its single source of truth). The old sideways
+   translateX slide that used to live here fought that file's vertical
+   lift, so it was removed — do not re-add paginav transforms here. */
 
 /* ---------- Icon controls: tap feedback + desktop hover ---------- */
 /* Header utility controls get the same tactile press as cards, plus a
@@ -410,11 +401,9 @@ button:focus-visible,
   .toc-highlight a:hover { transform: none !important; }
 
   /* Ripple is JS-gated off under reduced motion, but hard-hide any
-     ink that slips through and neutralise the pagination shift. */
+     ink that slips through. (Paginav motion is neutralised in
+     post-footer.css's own reduced-motion block.) */
   .ripple-ink { display: none !important; }
-  .paginav .prev:hover,
-  .paginav .next:hover,
-  .paginav a:active { transform: none !important; }
 
   .post-content a:not(.anchor):not(.btn) {
     background-size: 0 0 !important;

--- a/assets/css/extended/post-footer.css
+++ b/assets/css/extended/post-footer.css
@@ -3,10 +3,21 @@
    Style: editorial aesthetic-care, Stitch-inspired
    ─────────────────────────────────────────────── */
 
-/* ── Override PaperMod's default .paginav ───────────── */
+/* ── Override PaperMod's default .paginav ───────────────────────────
+   Single source of truth for the prev/next cards. Hover / press / lift
+   all live here; micro-interactions.css deliberately no longer touches
+   .paginav (its old sideways slide fought this file's vertical lift).
+
+   Motion language (Emil-style restraint):
+   • Only transform + box-shadow + colour move — GPU-friendly, no layout.
+   • Custom ease-out curve, sub-300ms — reads as intentional, not floaty.
+   • The card lifts a hair and casts a soft shadow; the brand accent is
+     spent only on the eyebrow + arrow, never a loud full-card border.
+*/
 .paginav {
   --rule: var(--color-rule, rgba(30, 35, 30, 0.08));
   --surface: var(--color-surface-low, #f4f4f2);
+  --ease-out: cubic-bezier(0.23, 1, 0.32, 1);
 
   display: grid !important;
   grid-template-columns: 1fr 1fr;
@@ -28,12 +39,13 @@
   width: 100% !important;
   padding: 22px 26px !important;
   border: 1px solid var(--rule) !important;
-  border-radius: 10px;
+  border-radius: 12px;
   background: var(--color-paper, #f9f9f7);
   color: var(--color-ink, #1a1c1b);
   text-decoration: none;
-  transition: border-color 220ms ease, background 220ms ease,
-              box-shadow 220ms ease, transform 260ms cubic-bezier(.2,.6,.2,1);
+  transition: border-color 240ms var(--ease-out),
+              box-shadow 240ms var(--ease-out),
+              transform 240ms var(--ease-out);
   overflow: hidden;
 }
 
@@ -41,27 +53,46 @@
 .paginav .prev { grid-column: 1; }
 .paginav .next { grid-column: 2; }
 
+/* A whisper of warmth pooling up from the base — barely there at rest,
+   just enough on hover to give the card a sense of depth. */
 .paginav a::before {
   content: "";
   position: absolute;
   inset: 0;
   background: linear-gradient(180deg,
-    transparent 0%,
-    var(--color-accent-soft, rgba(134, 33, 34, 0.035)) 100%);
+    transparent 30%,
+    var(--color-accent-soft, rgba(134, 33, 34, 0.05)) 100%);
   opacity: 0;
-  transition: opacity 240ms ease;
+  transition: opacity 240ms var(--ease-out);
   pointer-events: none;
 }
 
-.paginav a:hover {
-  border-color: var(--color-accent, #2e352e) !important;
-  background: var(--color-paper, #f9f9f7);
-  box-shadow: 0 8px 24px -12px rgba(30, 35, 30, 0.15);
-  transform: translateY(-1px);
+/* Two PaperMod defaults fight this design and must be neutralised:
+   • `.paginav a:hover { background: var(--border) }` flashes the card
+     grey on hover — keep our paper instead.
+   • `.paginav span:hover:not(.title) { box-shadow: 0 1px 0 }` draws a
+     hard 1px "underline" under the title span on hover — drop it; the
+     lift + border already signal the link. */
+.paginav a:hover { background: var(--color-paper, #f9f9f7) !important; }
+.paginav span:hover:not(.title) { box-shadow: none; }
+
+/* Hover is gated to fine pointers so a phone tap never sticks the
+   lifted state (touch gets the :active press below instead). */
+@media (hover: hover) and (pointer: fine) {
+  .paginav a:hover {
+    border-color: color-mix(in srgb,
+      var(--color-accent, #2e352e) 26%, rgba(30, 35, 30, 0.28)) !important;
+    box-shadow: 0 14px 30px -18px rgba(30, 35, 30, 0.28);
+    transform: translateY(-3px);
+  }
+  .paginav a:hover::before { opacity: 1; }
 }
 
-.paginav a:hover::before {
-  opacity: 0.4;
+/* Press: settle back down and compress a touch — confirms the tap
+   before the page turns. Snappy on release. */
+.paginav a:active {
+  transform: translateY(0) scale(0.99);
+  transition-duration: 120ms;
 }
 
 /* Eyebrow label ("« Prev" / "Next »") */
@@ -154,6 +185,67 @@
   justify-content: flex-end;
 }
 
+/* ── Lone card (newest / oldest post) ───────────────────────────────
+   On the newest post only "下一篇" exists, on the oldest only "上一篇".
+   A single half-width card stranded in one lane reads as broken, so the
+   lone card spans the full row and becomes a calm "up next" banner: the
+   eyebrow + title sit on the leading edge, and a large directional
+   chevron anchors the trailing edge and nudges on hover. */
+.paginav--single {
+  grid-template-columns: 1fr;
+}
+.paginav--single a {
+  min-height: 96px;
+  justify-content: center;
+}
+/* The large trailing chevron is the directional cue here, so the small
+   inline eyebrow arrow would just be a second arrow pointing the same
+   way — drop it. */
+.paginav--single .pagi-arrow { display: none; }
+/* Lone "下一篇" (older, forward): read left-to-right, chevron on the right. */
+.paginav--single .next,
+.paginav--single .next .title {
+  text-align: left;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+.paginav--single .next { padding-right: 68px !important; }
+/* Lone "上一篇" (newer, back): leave room for the chevron on the left. */
+.paginav--single .prev { padding-left: 68px !important; }
+
+.paginav--single a::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  width: 11px;
+  height: 11px;
+  border: solid var(--color-ink-muted, #5e5e63);
+  border-width: 1.8px 1.8px 0 0;
+  opacity: 0.32;
+  transition: transform 280ms var(--ease-out), opacity 240ms var(--ease-out),
+              border-color 240ms var(--ease-out);
+}
+.paginav--single .next::after {
+  right: 30px;
+  transform: translateY(-50%) rotate(45deg);
+}
+.paginav--single .prev::after {
+  left: 30px;
+  transform: translateY(-50%) rotate(-135deg);
+}
+@media (hover: hover) and (pointer: fine) {
+  .paginav--single .next:hover::after {
+    transform: translateY(-50%) translateX(4px) rotate(45deg);
+    opacity: 0.85;
+    border-color: var(--color-accent, #2e352e);
+  }
+  .paginav--single .prev:hover::after {
+    transform: translateY(-50%) translateX(-4px) rotate(-135deg);
+    opacity: 0.85;
+    border-color: var(--color-accent, #2e352e);
+  }
+}
+
 /* Mobile: stack */
 @media (max-width: 720px) {
   .paginav {
@@ -173,9 +265,18 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .paginav .pagi-arrow { transition: none; }
+  /* Keep the colour/shadow cues; drop every positional move. */
+  .paginav a,
+  .paginav .pagi-arrow,
+  .paginav--single a::after { transition: none; }
+  .paginav a:hover,
+  .paginav a:active { transform: none; }
   .paginav .prev:hover .pagi-arrow,
   .paginav .next:hover .pagi-arrow { transform: none; }
+  .paginav--single .next::after,
+  .paginav--single .next:hover::after { transform: translateY(-50%) rotate(45deg); }
+  .paginav--single .prev::after,
+  .paginav--single .prev:hover::after { transform: translateY(-50%) rotate(-135deg); }
 }
 
 /* Dark theme */
@@ -185,8 +286,13 @@ body.dark .paginav a {
 }
 
 body.dark .paginav a:hover {
-  border-color: rgba(255, 255, 255, 0.25) !important;
-  box-shadow: 0 8px 24px -12px rgba(0, 0, 0, 0.5);
+  background: rgba(255, 255, 255, 0.035) !important;
+  border-color: rgba(255, 255, 255, 0.22) !important;
+  box-shadow: 0 16px 34px -18px rgba(0, 0, 0, 0.66);
+}
+
+body.dark .paginav--single a::after {
+  border-color: rgba(255, 255, 255, 0.45);
 }
 
 

--- a/layouts/partials/post_nav_links.html
+++ b/layouts/partials/post_nav_links.html
@@ -3,8 +3,14 @@
      Series-aware: when the page carries `series: { slug, order }`,
      prev/next follow the series reading order (order-1 / order+1)
      instead of publish dates, so part 1 always points forward to
-     part 2 under "下一篇". Outside a series, reading order is
-     chronological: prev = published earlier, next = published later.
+     part 2 under "下一篇".
+
+     Outside a series, the reference frame is the archive as you
+     browse it: newest on top, oldest at the bottom. So "上一篇"
+     points UP the timeline (a newer post) and "下一篇" points DOWN
+     into the archive (an older post). On the newest post there is
+     nothing newer, so only "下一篇" (older) shows — which is what a
+     reader expects on the latest article.
 */ -}}
 {{- $page := . }}
 {{- $prev := "" }}
@@ -24,14 +30,16 @@
     {{- $pages = (where site.RegularPages "Lang" site.Language.Lang).ByDate.Reverse }}
   {{- end }}
   {{- if in $pages $page }}
-    {{- /* collection is newest-first: Prev = older, Next = newer */ -}}
-    {{- $prev = $pages.Prev $page }}
-    {{- $next = $pages.Next $page }}
+    {{- /* Collection is newest-first, so in the slice `.Next` is the
+           newer neighbour and `.Prev` is the older one. Map them to the
+           timeline metaphor above: "上一篇" = newer, "下一篇" = older. */ -}}
+    {{- $prev = $pages.Next $page }}
+    {{- $next = $pages.Prev $page }}
   {{- end }}
 {{- end }}
 {{- if or $prev $next }}
 {{- $isZh := eq $page.Lang "zh" }}
-<nav class="paginav{{ if $inSeries }} paginav--series{{ end }}" aria-label="{{ cond $isZh "文章导航" "Article navigation" }}">
+<nav class="paginav{{ if $inSeries }} paginav--series{{ end }}{{ if not (and $prev $next) }} paginav--single{{ end }}" aria-label="{{ cond $isZh "文章导航" "Article navigation" }}">
   {{- with $prev }}
   <a class="prev" href="{{ .Permalink }}">
     <span class="title">


### PR DESCRIPTION
## 背景

文章底部的「推荐」卡片（prev/next 导航）有三个问题，本 PR 逐一解决，并用 Playwright 在 light/dark、rest/hover、双卡、系列、移动端等场景逐一截图验证。

## 改动

### 1. 方向语义更符合直觉

非系列文章此前的映射是「上一篇 = 更旧、下一篇 = 更新」，导致**最新的一篇文章底部却显示「上一篇」指向旧文**，反直觉。

改为以「归档时间轴」为参照系（最新在上、最旧在下）：

- **上一篇** → 时间轴向上，指向**更新**的文章
- **下一篇** → 向下沉入归档，指向**更旧**的文章

于是最新文章只显示「下一篇」（指向次新的一篇），最旧文章只显示「上一篇」，符合读者预期。系列文章（`series.order`）的正向阅读顺序保持不变。

改动：`layouts/partials/post_nav_links.html` 里交换非系列分支的 `$prev`/`$next` 映射。

### 2. 悬浮动效更优雅

- `.paginav` 的交互样式统一由 `post-footer.css` 负责（单一来源），移除 `micro-interactions.css` 里与之打架的横向平移（`translateX(±3px)`）——正是它让 hover 显得「滑来滑去」不够优雅。
- 新 hover：自定义 `ease-out` 曲线（`cubic-bezier(.23,1,.32,1)`，<300ms）下的轻微上浮 + 柔和投影；品牌强调色只落在 eyebrow 标签与箭头上，**不再让整卡描边刺眼地泛红**。
- 补上 `:active` 按压反馈；`prefers-reduced-motion` 下退化为纯色/阴影提示，去掉所有位移。
- 仅使用 `transform` / `opacity` / 颜色过渡，GPU 友好、无重排。

### 3. 观感修复

- 中和 PaperMod 主题两个默认样式：hover 时标题下那条硬邦邦的 1px「下划线」（`.paginav span:hover:not(.title){box-shadow:0 1px 0}`），以及 hover 时把整卡刷成灰色的背景（`.paginav a:hover{background:var(--border)}`）。
- **仅剩一张卡时**（最新/最旧文）不再孤零零地缩在半栏里：卡片改为整行宽的「下一篇」横幅，尾部一枚随 hover 轻推的方向 chevron，`prev`/`next` 各自朝向正确。

## 验证

- ✅ 目标文章 `/zh/growth/posts/2026-07-20-the-player-is-also-a-role/`：现显示「下一篇 → 拆到最后…」，全宽横幅，无下划线、无灰底闪烁
- ✅ 双卡文章：左「上一篇」右「下一篇」，hover 上浮 + 柔和投影，平衡
- ✅ 系列文章单卡：横幅含系列标记「点火与沉底 · 第 2 篇」+ 尾部 chevron
- ✅ 移动端：单卡整行宽，标题 2 行截断，chevron 垂直居中
- ✅ 深浅色主题均已适配

> 编译验证使用 `hugo server`（0.145.0 extended，与 netlify.toml 一致）+ Playwright 截图逐轮迭代。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017HTs8cXPv1edG6XXwXGbyr

---
_Generated by [Claude Code](https://claude.ai/code/session_017HTs8cXPv1edG6XXwXGbyr)_