### PR TITLE
fix(code): 移动端代码块横向滚动到末尾不遮挡最后一个字符

### DIFF
--- a/assets/css/extended/zzz-code-mobile.css
+++ b/assets/css/extended/zzz-code-mobile.css
@@ -21,11 +21,31 @@
    Loaded late (zzz- prefix) so it composes over the theme.
    ============================================================ */
 
-/* ── 0. Scroll hygiene: the real scroller is `pre code` ─────── */
-.post-content pre:not(.mermaid) code {
+/* ── 0. Scroll hygiene: the <pre> is the horizontal scroller ──
+   The inner `code` used to scroll, but a scroll container's own
+   `padding-right` is dropped from the scrollable extent in WebKit /
+   iOS Safari. So at the far end of a sideways swipe the last glyph
+   sat flush against the frame, and momentum-scroll snapped back with
+   it still clipped — you could drag it into view but never rest there.
+
+   Fix: let the <pre> scroll and make `code` an inline-block child that
+   carries the padding. A child's padding box is always counted in an
+   ancestor's scroll extent (every engine, Safari included), so the
+   trailing gutter survives to the very end of the scroll. */
+.post-content pre:not(.mermaid) {
+  overflow-x: auto;
   /* Reaching the end of a sideways swipe must not leak into the
      browser's history-swipe / page navigation. */
   overscroll-behavior-x: contain;
+}
+.post-content pre:not(.mermaid) > code {
+  display: inline-block;
+  min-width: 100%;
+  box-sizing: border-box;
+  vertical-align: top;
+  /* the <pre> owns the horizontal scroll now; the code box just holds
+     content (and its own left/right padding). */
+  overflow: visible;
 }
 
 /* ── 1. Full-bleed on phones ────────────────────────────────── */
@@ -52,10 +72,14 @@
 }
 
 /* ── 2. Soft-wrap state ─────────────────────────────────────── */
-.post-content pre.code-wrap code {
+.post-content pre.code-wrap {
+  /* Wrapped blocks have nothing off-screen, so the <pre> must not
+     scroll (an empty scroll would still let momentum rubber-band). */
+  overflow-x: hidden;
+}
+.post-content pre.code-wrap > code {
   white-space: pre-wrap !important;
   word-break: break-word !important;
-  overflow-x: visible;
 }
 
 /* ── 3. Fullscreen button ───────────────────────────────────── */
@@ -216,6 +240,13 @@
 }
 
 .code-fs-content pre code {
+  /* The reader's single scroller is .code-fs-scroll and the <pre> is
+     sized to max-content, so here the code is a plain block again —
+     not the in-article inline-block scroll carrier (§0). Reset it, or
+     `min-width:100%` against a max-content <pre> sizes circularly and
+     collapses the clone. */
+  display: block !important;
+  min-width: 0 !important;
   overflow: visible !important;
   white-space: pre !important;
   font-size: var(--code-fs-size, 14px) !important;

--- a/static/js/code-mobile.js
+++ b/static/js/code-mobile.js
@@ -89,7 +89,9 @@
     var pre = code.parentNode;
     var container = pre.closest('.highlight') || pre;
     var wrapped = pre.classList.contains('code-wrap');
-    var overflows = code.scrollWidth - code.clientWidth > 2;
+    /* The <pre> is the horizontal scroller (zzz-code-mobile.css §0), so
+       overflow is measured on it, not the inline-block code child. */
+    var overflows = pre.scrollWidth - pre.clientWidth > 2;
     if (wrapped || overflows) {
       var tools = ensureTools(code);
       tools.style.display = '';

--- a/static/js/wide-content-scroll.js
+++ b/static/js/wide-content-scroll.js
@@ -32,15 +32,11 @@
     return Array.prototype.slice.call(document.querySelectorAll(SEL));
   }
 
-  /* For code blocks the actual scroll container is the inner <code>
-     (the <pre> itself is overflow:hidden), so measuring/listening on
-     the <pre> never saw any overflow and the cue never appeared. Keep
-     the fade class + vars on the <pre> (the CSS mask target), but do
-     all measuring and scroll-listening on the real scroller. */
+  /* The <pre> and <table> are themselves the horizontal scrollers
+     (zzz-code-mobile.css §0 moved the code scroll from the inner
+     <code> onto the <pre> so trailing padding survives to the scroll
+     end), so measure and listen on the element itself. */
   function scrollerOf(el) {
-    if (el.tagName === 'PRE' && el.firstElementChild && el.firstElementChild.tagName === 'CODE') {
-      return el.firstElementChild;
-    }
     return el;
   }
 


### PR DESCRIPTION
## 问题

手机端浏览文章时，代码块内容较宽需要横向滑动。滑到最右端时，**最后一个字符无法完整显示**：可以拖过去瞄一眼，但松手回弹后最后一个字仍被遮挡在边缘。

## 根因

代码块的真正滚动容器是内层 `<code>`（`overflow-x: auto` + `padding`）。在 **iOS / WebKit** 上，滚动容器**自身的 `padding-right` 不计入可滚动范围（scrollWidth）**。于是滚到最右端时，内容右边缘恰好贴到 padding 盒边缘——右侧留白视觉上消失，最后一个字符贴边；配合惯性回弹（rubber-banding），松手后停在这个位置，字符依旧被截。

> 我用真实浏览器做了对照实验（把容器 `padding-right` 归零模拟 Safari 的行为）：
> - 给每行 `.line` 加 `padding-right` —— 失效，因为换行符 `\n` 在 `.cl` 内部、行尾，内边距落到了换行之后；
> - 尾部伪元素 spacer —— 当最宽行不是最后一行时也失效；
> - **让 `<pre>` 滚动、`<code>` 作为 inline-block 子元素承载内边距 —— 即使容器 padding 归零，最宽行末尾仍保留 14px 留白。** ✅

## 方案

把横向滚动从内层 `<code>` 移到外层 `<pre>`，`<code>` 改为 `inline-block; min-width:100%` 的子元素并保留内边距。**子元素的 padding 盒在所有引擎（含 Safari）都会计入祖先的滚动范围**，尾部留白因此能一直保留到滚动终点。

### 改动

- **`assets/css/extended/zzz-code-mobile.css`**
  - §0：`<pre>` 承担横向滚动与 `overscroll-behavior-x: contain`；`<code>` 改 `inline-block / min-width:100% / box-sizing:border-box / vertical-align:top`
  - §2：软换行块（bash 等）的 `<pre>` 设 `overflow-x: hidden`，避免空滚动被惯性回弹
  - §4：全屏阅读器内 `<code>` 复位为 `display:block; min-width:0`，避免与阅读器 `<pre> { width:max-content }` 循环取值导致克隆内容塌缩
- **`static/js/code-mobile.js`**：溢出检测（全屏按钮显隐）改为测量 `<pre>`
- **`static/js/wide-content-scroll.js`**：滑动渐隐提示的测量/监听目标改为元素自身

## 验证

用项目所需 Hugo（0.147.0 extended）本地构建，并用预置 Chromium 在移动/桌面视口实测：

- ✅ 代码块滑到最右端，最宽行（含非末行为最宽的情形）末尾保留约 14px 留白，最后一个字符完整可见
- ✅ 全出血布局不产生页面级横向溢出（`document` 无水平溢出）
- ✅ 全屏按钮、左右渐隐提示正常；bash 等语言默认软换行正常
- ✅ 全屏阅读器克隆内容渲染与滚动正常，无塌缩
- ✅ 真实文章（advanced-githook-design）14 个代码块回归通过，桌面端工具按钮正确隐藏，控制台 0 报错
- ✅ 深浅色内层滚动条样式已覆盖 `<pre>`，无回归

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BVWN7yMTbpvXEyzNiixjUJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BVWN7yMTbpvXEyzNiixjUJ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved horizontal scrolling for mobile code blocks, including access to trailing content.
  * Prevented unwanted horizontal scrolling when code is soft-wrapped.
  * Fixed fullscreen code reader sizing and layout.
  * Corrected detection and display of code-block expansion controls.
  * Restored wide-content scroll cues for overflowing code blocks and tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->