### PR TITLE
feat(related-posts): 相关文章不足 3 篇时用同 section 最新文章兜底

### DIFF
--- a/layouts/partials/related-posts.html
+++ b/layouts/partials/related-posts.html
@@ -1,4 +1,14 @@
 {{- $related := .Site.RegularPages.Related . | first 3 -}}
+{{- /* 兜底：tags/keywords 命中不足 3 篇时（threshold 高，很多文章会命中 0），
+       用同 section 的最新文章补齐，保证每篇文章都有内链出口（SEO 回游）。
+       补齐项排除当前页与已命中的相关文章，按站点默认的日期倒序取新。 */ -}}
+{{- if lt (len $related) 3 -}}
+  {{- $need := sub 3 (len $related) -}}
+  {{- $exclude := $related | append . -}}
+  {{- $pool := where .Site.RegularPages "Section" .Section -}}
+  {{- $fill := first $need (complement $exclude $pool) -}}
+  {{- $related = $related | append $fill -}}
+{{- end -}}
 {{- with $related -}}
 <section class="related-posts">
   <div class="related-posts-header">


### PR DESCRIPTION
## 背景

文章尾部的「相关文章 / Related Posts」用 Hugo `Related`(tags 权重 80 + keywords 权重 20,`threshold: 80`)取前 3 篇。由于阈值较高,**很多文章命中 0 篇**,此时 `{{- with $related -}}` 会让整块消失,导致这些文章尾部**没有任何内链出口**——损失 SEO 回游导线与主题簇内链,也让页面尾部更空。

评估结论:这个模块设计本身优雅、且对 SEO(内链)是实打实有用的,应当保留而非替换;GEO 主要由 `seo/structured-data.html` 的 JSON-LD 承担。所以只补上「命中不足时消失」这个最大漏洞。

## 改动

`layouts/partials/related-posts.html`:命中不足 3 篇时,用**同 section 的最新文章**补齐到 3 篇。

- 补齐项排除当前页与已命中的相关文章(`complement`),不重复
- 命中项仍排在最前,保留相关度优先的顺序
- 补齐按站点默认日期倒序取新
- 卡片设计、图片处理、样式均未改动

## 验证

用标准版 Hugo 0.145.0 搭最小站点隔离验证该 partial 的兜底逻辑(内容无封面,不涉及 WebP):

- 命中 0 篇 → 用同 section 最新 3 篇补齐;当前页与其他 section 均不出现 ✅
- 命中 1 篇 → 命中项排首位,再补 2 篇且不与命中项重复,正好 3 篇 ✅
- 命中 ≥3 篇 → 兜底分支不触发,行为与原来一致 ✅
- 两种情况构建均 exit 0,无模板错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Juh6Z1e7C9k4p5BmSBKQaB)_