### PR TITLE
feat(toc): 侧栏目录改为「当前章节渐进展开」的层级显示

### DIFF
--- a/assets/css/extended/editorial-tools.css
+++ b/assets/css/extended/editorial-tools.css
@@ -307,10 +307,12 @@ html:lang(zh) body.dark .editorial-tools-panel .toc-side__nav:hover .toc-item a.
   opacity: 1;
 }
 
-/* Indent sub-headings progressively; each level recedes a step */
+/* Depth is carried by indentation (and, when grouped, by reveal state) — not
+   by shrinking type. Font size stays near-constant so sub-headings never turn
+   into unreadable fine print; each level just steps in by one rail-width. */
 .editorial-tools-panel .toc-item--h3 a {
-  padding-left: 14px;
-  font-size: 12.5px;
+  padding-left: 16px;
+  font-size: 13px;
   opacity: 0.5;
 }
 
@@ -318,15 +320,79 @@ body.dark .editorial-tools-panel .toc-item--h3 a {
   opacity: 0.52;
 }
 .editorial-tools-panel .toc-item--h4 a {
-  padding-left: 26px;
-  font-size: 12px;
+  padding-left: 30px;
+  font-size: 12.5px;
   opacity: 0.46;
 }
 .editorial-tools-panel .toc-item--h5 a,
 .editorial-tools-panel .toc-item--h6 a {
-  padding-left: 36px;
-  font-size: 11.5px;
+  padding-left: 42px;
+  font-size: 12px;
   opacity: 0.44;
+}
+
+/* ────────────────────────────────────────────────────────────────
+   PROGRESSIVE DISCLOSURE — reveal only the current section
+   Applied when reading-companion.js finds nested headings and adds
+   .toc-side__nav--grouped. Sub-headings of every *other* section collapse
+   to nothing; the section the reader is in expands. Hovering the outline
+   peeks the whole thing, so nothing is ever truly hidden.
+   ──────────────────────────────────────────────────────────────── */
+
+/* Section anchors sit a touch tighter so each section reads as one block. */
+.editorial-tools-panel .toc-side__nav--grouped .toc-item {
+  transition: margin 200ms ease;
+}
+.editorial-tools-panel .toc-side__nav--grouped .toc-item--sub {
+  overflow: hidden;
+  max-height: 2.4em;
+  opacity: 1;
+  transition: max-height 260ms cubic-bezier(0.22, 1, 0.36, 1),
+              opacity 180ms ease;
+}
+.editorial-tools-panel .toc-side__nav--grouped .toc-item--sub.toc-collapsed {
+  max-height: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+
+/* Revealed children sit just under the lit anchor — present, not shouting. */
+.editorial-tools-panel .toc-side__nav--grouped .toc-item--sub:not(.toc-collapsed) a {
+  opacity: 0.62;
+}
+
+/* The current section's anchor stays full-ink while you read its children,
+   so parent + revealed children form one lit block and the rest recede. */
+.editorial-tools-panel .toc-item.toc-section-current > a {
+  color: var(--color-ink, #1a1c1b);
+  opacity: 1;
+  font-weight: 500;
+}
+body.dark .editorial-tools-panel .toc-item.toc-section-current > a {
+  color: var(--color-ink, #e2e3e1);
+}
+html:lang(zh) body.dark .editorial-tools-panel .toc-item.toc-section-current > a {
+  color: var(--color-ink, #f5f3ee);
+}
+
+/* A faint, persistent rail tick marks the current section on the anchor even
+   when the live position (the bright tick) is on one of its children. */
+.editorial-tools-panel .toc-side__nav--grouped .toc-item.toc-section-current:not(:has(> a.toc-active))::before {
+  opacity: 0.32;
+  transform: translateY(-50%) scaleY(1);
+}
+
+/* Peek the full outline on hover — collapsed children ease back in, faint. */
+.editorial-tools-panel .toc-side__nav--grouped:hover .toc-item--sub.toc-collapsed {
+  max-height: 2.4em;
+  opacity: 0.5;
+  pointer-events: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .editorial-tools-panel .toc-side__nav--grouped .toc-item--sub {
+    transition: none;
+  }
 }
 
 /* ────────────────────────────────────────────────────────────────

--- a/static/js/reading-companion.js
+++ b/static/js/reading-companion.js
@@ -81,7 +81,8 @@
 
   // ─── 2. TOC Scroll Highlighting ───────────────────────────────────────────
   function initTocHighlight() {
-    var tocLinks = document.querySelectorAll('.toc-side__nav a');
+    var nav = document.querySelector('.toc-side__nav');
+    var tocLinks = nav ? nav.querySelectorAll('a') : [];
     if (!tocLinks.length) return;
 
     var sections = [];
@@ -99,6 +100,57 @@
       if (heading) sections.push({ heading: heading, link: link });
     });
     if (!sections.length) return;
+
+    // ── Progressive disclosure: group the flat TOC into sections ──
+    // The outline is a single flat <ul>; H2/H3/H4 are siblings, not nested.
+    // We treat the shallowest heading level present as the "section anchor"
+    // (always visible) and gather each anchor's deeper headings as its
+    // collapsible children. Only the section the reader is currently in stays
+    // expanded — the rest recede to their anchors, so the panel reads as a
+    // short map instead of a wall of every subheading at once.
+    var items = Array.prototype.slice.call(nav.querySelectorAll('.toc-item'));
+    var groupOf = null; // Map: .toc-item li -> group index
+    var groups = [];    // [{ anchor: li|null, subs: [li,…] }]
+    if (items.length) {
+      groupOf = (typeof Map === 'function') ? new Map() : null;
+      var levelOf = function (li) {
+        var a = li.querySelector('a');
+        return a ? (parseInt(a.getAttribute('data-level'), 10) || 2) : 2;
+      };
+      var topLevel = items.reduce(function (min, li) {
+        return Math.min(min, levelOf(li));
+      }, 99);
+      var cursor = -1;
+      items.forEach(function (li) {
+        if (levelOf(li) <= topLevel) {
+          cursor = groups.length;
+          groups.push({ anchor: li, subs: [] });
+        } else {
+          if (cursor === -1) { cursor = groups.length; groups.push({ anchor: null, subs: [] }); }
+          groups[cursor].subs.push(li);
+          li.classList.add('toc-item--sub');
+        }
+        if (groupOf) groupOf.set(li, cursor);
+      });
+      // Only worth collapsing when at least one section actually has children.
+      var hasNesting = groups.some(function (g) { return g.subs.length; });
+      if (hasNesting) nav.classList.add('toc-side__nav--grouped');
+      else { groups = []; groupOf = null; }
+    }
+
+    var openGroup = -1;
+    function setOpenGroup(gi) {
+      if (!groups.length || gi === openGroup) return;
+      openGroup = gi;
+      for (var i = 0; i < groups.length; i++) {
+        var open = (i === gi);
+        var g = groups[i];
+        if (g.anchor) g.anchor.classList.toggle('toc-section-current', open);
+        for (var j = 0; j < g.subs.length; j++) {
+          g.subs[j].classList.toggle('toc-collapsed', !open);
+        }
+      }
+    }
 
     var currentActive = null;
     var OFFSET = 140;
@@ -128,6 +180,17 @@
           activeSection = sections[i];
           break;
         }
+      }
+      // Reveal the section the reader is in (falls back to the first group
+      // while still above the first heading), independent of whether the
+      // active *link* changed — keeps the open section correct on load.
+      if (groups.length) {
+        var gi = 0;
+        if (activeSection) {
+          var li = activeSection.link.closest('.toc-item');
+          if (li && groupOf && groupOf.has(li)) gi = groupOf.get(li);
+        }
+        setOpenGroup(gi);
       }
       if (activeSection === currentActive) return;
       if (currentActive) currentActive.link.classList.remove('toc-active');


### PR DESCRIPTION
## 背景

侧栏阅读伴随目录（`.toc-side__nav`，`layouts/partials/article/editorial-tools.html`）原来用**缩进 + 缩小字号 + 降低透明度**三个通道同时表达层级。三通道叠加导致每个都"不敢用力"：所有章节的子标题一次性铺满、章节不成块、字号越深越小到难以辨认，整份目录读起来像一条被轻微缩进过的流水账。

## 改动

改为**当前章节渐进展开**（Stripe / Tailwind 文档式）：

- 顶层标题常驻，**只展开读者当前所在章节的子标题**，其余章节收起为锚点 —— 目录始终是一张短地图，而不是一堵墙。
- 当前章节锚点满墨、带左侧 rail tick，父标题与其子标题形成一个点亮的块，其余章节自然退隐。
- **hover 整份大纲会淡淡浮现**，任何内容都不会被真正隐藏。
- 字号不再逐级缩小，深度改由缩进（+ 展开状态）承载，子标题不再变成难读的小字。
- 仅当目录存在嵌套时启用（JS 加 `.toc-side__nav--grouped`）；纯 H2 目录行为保持不变。
- 尊重 `prefers-reduced-motion`。

## 实现

- `static/js/reading-companion.js`：`initTocHighlight` 把扁平 `<ul>`（H2/H3/H4 本是同级 `<li>`）按最浅标题层级分组；滚动时定位当前段并调用 `setOpenGroup` 切换展开/折叠与当前段标记。
- `assets/css/extended/editorial-tools.css`：新增折叠/展开过渡、当前段锚点点亮、hover 全展开、以及归一化后的各级字号规则。

## 验证

因运行环境的代理拦截了 GitHub 二进制下载，`netlify dev`（需 Hugo 0.145）无法在此环境起服务。改用预装 Chromium + Playwright，复现模板输出的**真实 DOM 结构**并注入改动后的**真实 CSS/JS**，用截图里的完整目录结构驱动滚动做不变量校验：

- ✅ 存在嵌套时加上 `.toc-side__nav--grouped`
- ✅ 三个不同滚动位置（含 2/3/5 个子标题的章节）：恰好当前段展开、其子项全部可见、其余章节子项全部折叠、当前段锚点点亮
- ✅ hover 时 12/12 子标题全部浮现
- ✅ 无 JS 运行时错误

（渲染截图见改动后的 scrolled / hover 两态，均符合设计预期。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BCFXLXbHM7ddbdSrSwgKGL)_