### PR TITLE
style(series): 系列侧栏悬浮即优雅展开，无需点击小箭头

### DIFF
--- a/assets/css/extended/article-series.css
+++ b/assets/css/extended/article-series.css
@@ -49,14 +49,16 @@
   margin-left: auto;
   color: var(--color-ink, #1a1c1b);
   opacity: 0.4;
-  transition: transform 220ms ease, opacity 220ms ease;
+  transition: transform 300ms cubic-bezier(0.22, 0.61, 0.36, 1), opacity 220ms ease;
 }
+/* Caret turns down whenever the panel is open — on hover, on keyboard
+   focus, or after an explicit toggle. It reads as an affordance, not a
+   button you must hunt for and click. */
+.marginalia-series-disclose:hover .marginalia-series-caret,
+.marginalia-series-disclose:focus-within .marginalia-series-caret,
 .marginalia-series-disclose[open] .marginalia-series-caret {
   transform: rotate(90deg);
-  opacity: 0.7;
-}
-.marginalia-series-disclose:hover .marginalia-series-caret {
-  opacity: 0.75;
+  opacity: 0.72;
 }
 
 /* Series name — now a link to the column page */
@@ -73,14 +75,40 @@
   outline: none;
 }
 
-/* Expanded list reveal animation */
-.marginalia-series-disclose[open] .marginalia-series-list {
-  animation: marginalia-series-reveal 240ms ease;
-  margin-top: 0.65rem;
+/* ── Hover / focus / toggle reveal ────────────────────────────────────
+   The list unfurls the instant the pointer rests on the group — no click,
+   no hunting for the caret. Keyboard focus and an explicit <details>
+   toggle open it too; touch and legacy browsers fall back to the native
+   click. The animation lives on ::details-content, whose own height is
+   driven by a 0fr→1fr grid track so it eases open and shut at its natural
+   height. content-visibility rides along with allow-discrete so the panel
+   stays painted through the entire close, then drops out cleanly. */
+.marginalia-series-disclose::details-content {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  /* clip vertically for the collapse; keep the horizontal axis visible so
+     the current-item timeline dot (which sits left of the rule) is never
+     shaved off. */
+  overflow-x: visible;
+  overflow-y: clip;
+  content-visibility: hidden;
+  transition:
+    grid-template-rows 340ms cubic-bezier(0.22, 0.61, 0.36, 1),
+    opacity 260ms ease,
+    content-visibility 340ms allow-discrete;
 }
-@keyframes marginalia-series-reveal {
-  from { opacity: 0; transform: translateY(-2px); }
-  to   { opacity: 1; transform: translateY(0); }
+.marginalia-series-disclose:hover::details-content,
+.marginalia-series-disclose:focus-within::details-content,
+.marginalia-series-disclose[open]::details-content {
+  grid-template-rows: 1fr;
+  opacity: 1;
+  content-visibility: visible;
+}
+/* The grid track's child must be free to shrink to zero for the reveal. */
+.marginalia-series-disclose .marginalia-series-list {
+  min-height: 0;
+  margin: 0;
 }
 
 .marginalia-series {
@@ -123,14 +151,27 @@
   margin: 0 0.18rem;
 }
 
-/* Vertical timeline of the series — single hairline rule, no boxes */
+/* Vertical timeline of the series — single hairline rule, no boxes.
+   The 0.7rem top padding is the breathing room under the summary; because
+   it lives inside the collapsing panel it eases open/shut with it. The rule
+   is drawn as a ::before starting below that padding, so it still begins at
+   the first item rather than floating up into the gap. */
 .marginalia-series-list {
+  position: relative;
   list-style: none;
   margin: 0;
-  padding: 0 0 0 0.55rem;
+  padding: 0.7rem 0 0 0.55rem;
   display: grid;
   gap: 0.32rem;
-  border-left: 1px solid color-mix(in oklab, var(--color-ink, #1a1c1b) 14%, transparent);
+}
+.marginalia-series-list::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0.7rem;
+  bottom: 0;
+  width: 1px;
+  background: color-mix(in oklab, var(--color-ink, #1a1c1b) 14%, transparent);
 }
 .marginalia-series-item {
   position: relative;
@@ -515,9 +556,9 @@ body.dark .rc-series-title,
 body.dark .abs-series-title {
   color: var(--primary, #e8e6e3);
 }
-.dark .marginalia-series-list,
-body.dark .marginalia-series-list {
-  border-left-color: color-mix(in oklab, var(--primary, #e8e6e3) 18%, transparent);
+.dark .marginalia-series-list::before,
+body.dark .marginalia-series-list::before {
+  background: color-mix(in oklab, var(--primary, #e8e6e3) 18%, transparent);
 }
 .dark .rc-series-head,
 .dark .abs-series-head,
@@ -537,7 +578,9 @@ body.dark .abs-series-num {
    Drop the position travel (list reveal slide, arrow nudge); keep the
    opacity/colour changes that aid comprehension. */
 @media (prefers-reduced-motion: reduce) {
-  .marginalia-series-disclose[open] .marginalia-series-list { animation: none; }
+  /* Reveal still works on hover/focus/toggle — just no height easing. */
+  .marginalia-series-disclose::details-content { transition: none; }
+  .marginalia-series-caret { transition: opacity 220ms ease; }
   .rc-series-link:hover .rc-series-arrow,
   .rc-series-link:focus-visible .rc-series-arrow { transform: none; }
 }


### PR DESCRIPTION
## 背景

系列文章左侧 marginalia 的「系列」组，此前必须点击最右侧那个很小的展开箭头，才能看到整套系列目录。发现成本高、点击目标小，体验不够自然。

## 改动

把「点击展开」改为**指针悬停即优雅展开**（同时兼容键盘 focus 与显式 toggle）：

- 展开动画迁移到 `::details-content`，用 `0fr → 1fr` 的 grid 轨道驱动面板自身高度，配合 `content-visibility` 的 `allow-discrete`——展开与收起都在其**自然高度**上平滑过渡，没有割裂的跳变，收起时也一直保持绘制直到动画结束再干净退出。
- 折叠只在**竖直方向 `clip`**，水平方向保持 `visible`，因此当前篇的时间线圆点（位于竖线左侧）不会被裁掉。
- 时间线竖线从 `border-left` 改为 `::before` 绘制，顶部留白随面板一起折叠，竖线仍从第一条目开始（视觉与原设计一致）。
- caret 在 `hover / focus-within / open` 时统一转向,作为一个可被发现的提示,而不是必须去找、去点的按钮。

## 兼容与降级

- **触摸端**与不支持 `::details-content` 的旧浏览器：回退到原生 `<details>` 点击展开，功能不受影响。
- **键盘**：原生 `<details>` 的 focus + Enter 展开链路保留，`:focus-within` 额外让 tab 进入列表时保持展开。
- **`prefers-reduced-motion`**：取消高度缓动，但悬停/点击仍可正常展开。

## 验证

用 Hugo 0.145.0+extended 本地构建（0 报错）并在 Chromium(Playwright) 里驱动真实页面 `/zh/ai-agent/posts/super-individual-stack-production/`：

- 折叠态：列表隐藏 ✅
- 悬停：面板平滑展开(测得逐帧高度 11 → 144 → 270px，缓动确实在跑)，caret 旋转 0° → 90°，当前篇圆点未被裁切 ✅
- 移开指针：干净收回 ✅
- 深色模式：时间线竖线与当前篇圆点渲染正常 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TPCTksx43UQAH5xHdGc3pK

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPCTksx43UQAH5xHdGc3pK)_