### PR TITLE
perf(seo): 修复隐藏微信缩略图拖爆 LCP + CJK 标题假截断 + 日报 SEO 建议落地

### DIFF
--- a/content/en/ai-agent/posts/gpt-researcher.md
+++ b/content/en/ai-agent/posts/gpt-researcher.md
@@ -13,7 +13,7 @@ tags:
   - Open Source
   - Project Learning
 description: >
-  GPT Researcher is an open source AI agent that turns 20+ web sources into 2,000+ word research reports in minutes. Learn its architecture, setup, and cost.
+  GPT Researcher is a free, self-hosted alternative to ChatGPT Deep Research: an open source agent that turns 20+ web sources into cited 2,000+ word reports in minutes. This deep dive covers its LangGraph multi-agent architecture, installation with Docker, real API costs, and when to pick it over closed tools.
 aliases:
   - /posts/ai-projects/gpt-researcher/
 tldr:

--- a/content/en/engineering/posts/go-release-tools.md
+++ b/content/en/engineering/posts/go-release-tools.md
@@ -1,15 +1,15 @@
 ---
-title: 'GoReleaser: Automate your software releases'
+title: 'GoReleaser Tutorial: .goreleaser.yaml Config Guide'
 ShowRssButtonInSectionTermList: true
 date: '2023-09-16T16:07:39+08:00'
 draft: false
 showtoc: true
 tocopen: false
 author: ["Xinwei Xiong", "Me"]
-keywords: ['GoReleaser', 'Software Releases', 'Release Automation', 'Go Programming Language', 'Continuous Integration', 'Continuous Deployment']
+keywords: ['GoReleaser', 'goreleaser.yaml', 'GoReleaser configuration', 'name_template', 'Go release automation', 'GitHub Actions', 'Continuous Integration', 'Continuous Deployment']
 tags: ["Blog", "Go", "DevOps"]
 description: >
-    Learn how to streamline and automate your software release process using GoReleaser, a powerful tool for Go projects.
+    Hands-on GoReleaser tutorial: generate .goreleaser.yaml with goreleaser init, then walk through builds, archives, name_template, Docker images, signing, and GitHub Release settings — ending with a full GitHub Actions release pipeline for Go projects.
 tldr:
   - "GoReleaser automates software release workflows for Go projects through four stages: defaulting, building, releasing, and announcing, with sensible defaults and extensive customization options."
   - "The tool builds multi-platform binaries, creates archives and packages, generates Docker images, and produces checksums while supporting GPG/Cosign signing for security verification."

--- a/content/zh/ai-agent/posts/gpt-researcher.md
+++ b/content/zh/ai-agent/posts/gpt-researcher.md
@@ -10,7 +10,7 @@ keywords: []
 tags: ["AI", "Project Learning"]
 author: ["Xinwei Xiong", "Me"]
 description: >
-  GPT Researcher 是开源自主 AI 研究代理，聚合 20 多个信息源，几分钟内生成 2000 词以上的深度研究报告。本文拆解其多代理架构、LangGraph 工作流与检索抓取模块，并给出安装配置步骤、成本考量与系统学习路径。
+  GPT Researcher 是 ChatGPT Deep Research 的免费开源替代品：可自托管的 AI 研究代理，聚合 20 多个信息源，几分钟生成带引用的 2000 词深度报告。本文拆解其 LangGraph 多代理架构与检索抓取模块，给出 Docker 安装步骤、真实 API 成本，以及何时该选它而非闭源方案。
 aliases:
   - /zh/posts/ai-projects/gpt-researcher/
 tldr:

--- a/content/zh/engineering/posts/go-release-tools.md
+++ b/content/zh/engineering/posts/go-release-tools.md
@@ -1,5 +1,5 @@
 ---
-title: 'GoReleaser：自动化你的软件发布'
+title: 'GoReleaser 教程：goreleaser.yaml 配置与发布自动化实战'
 ShowRssButtonInSectionTermList: true
 date: 2023-09-16T16:07:39+08:00
 draft: false
@@ -7,9 +7,9 @@ showtoc: true
 tocopen: false
 type: posts
 author: '熊鑫伟，我'
-keywords: ['GoReleaser', 'CI/CD', '自动化发布', 'Golang ', '软件开发']
+keywords: ['GoReleaser', 'goreleaser.yaml', 'GoReleaser 配置', 'Go release', 'CI/CD', '自动化发布', 'GitHub Actions', 'Golang']
 tags: ["DevOps", "Go"]
-description: '本文介绍 GoReleaser 工具，一个帮助开发者自动化软件发布流程的强大工具。通过使用 GoReleaser，你可以简化构建、打包和发布软件的步骤，提高开发效率。'
+description: 'GoReleaser 实战教程：从 goreleaser init 生成 .goreleaser.yaml 开始，逐段讲解 builds、archives、name_template、Docker 镜像、签名与 GitHub Release 配置，并给出接入 GitHub Actions 的完整自动化发布流程。'
 tldr:
   - "GoReleaser通过defaulting、building、releasing、announcing四个步骤完全自动化Go项目的软件发布流程，支持多平台构建、Docker镜像推送、GitHub发布等功能。"
   - "开发者可在.goreleaser.yaml配置文件中自定义构建选项、打包格式、签名认证、云存储上传等参数，实现灵活高效的发布工作流。"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -32,7 +32,10 @@
     {{- $pagerSuffix = printf " - Page %d" .Paginator.PageNumber -}}
   {{- end -}}
 {{- end -}}
-{{- $titleCore := cond (gt (len $baseTitle) 50) (printf "%s…" (substr $baseTitle 0 50)) $baseTitle -}}
+{{- /* len counts BYTES, but substr counts runes — a 40-char Chinese title is
+     ~120 bytes, so every CJK title used to get a spurious trailing "…" while
+     keeping its full text. Compare runes against runes. */ -}}
+{{- $titleCore := cond (gt (strings.RuneCount $baseTitle) 50) (printf "%s…" (substr $baseTitle 0 50)) $baseTitle -}}
 {{- $pageTitle := cond .IsHome site.Title (printf "%s%s | %s" $titleCore $pagerSuffix $shortTitle) -}}
 <title>{{ $pageTitle }}</title>
 {{- partial "seo.html" . -}}

--- a/layouts/partials/wechat-share-thumb.html
+++ b/layouts/partials/wechat-share-thumb.html
@@ -4,7 +4,14 @@
        that would be the 48px author avatar or, worse, an SVG cover it can't
        use. Plant the thumbnail deterministically instead: the cover when it
        is a locally-hosted raster, otherwise the section OG card (1200×630).
-       Clipped via 0×0 overflow — display:none would stop the fetch. */ -}}
+       Clipped via 0×0 overflow — display:none would stop the fetch.
+
+       Perf: this hidden img used to load the FULL-RESOLUTION cover with
+       loading="eager", racing (and losing to no one but itself) against the
+       visible hero's 720w srcset variant — mobile LCP on image-heavy posts
+       hit 10-19s (see issue #257). WeChat only needs ≥300px, so serve a
+       640px resized variant via Hugo Pipes and load it lazily at low
+       priority; WeChat reads the src from the DOM either way. */ -}}
 {{- $sectionDefault := dict "ai-agent" "/assets/og-ai-technology.png" "engineering" "/assets/og-ai-technology.png" "growth" "/assets/og-growth.png" "projects" "/assets/og-projects.png" -}}
 {{- $thumb := index $sectionDefault .Section | default (index (site.Params.images | default (slice "/assets/og-image.png")) 0) -}}
 {{- with .Params.cover.image -}}
@@ -14,6 +21,22 @@
     {{- $thumb = . -}}
   {{- end -}}
 {{- end -}}
+{{- /* Root-absolute /images/… covers resolve through the static/images →
+       assets/images module mount, so Hugo Pipes can downscale them. Anything
+       else (e.g. /assets/og-*.png defaults, not mounted) falls back to the
+       raw URL — those OG cards are already small. */ -}}
+{{- $thumbURL := $thumb | absURL -}}
+{{- $w := 1200 -}}{{- $h := 630 -}}
+{{- if hasPrefix $thumb "/images/" -}}
+  {{- with resources.Get (strings.TrimPrefix "/" $thumb) -}}
+    {{- if and (eq .ResourceType "image") (ne .MediaType.SubType "svg") -}}
+      {{- $small := . -}}
+      {{- if gt .Width 640 -}}{{- $small = .Resize "640x" -}}{{- end -}}
+      {{- $thumbURL = $small.Permalink -}}
+      {{- $w = $small.Width -}}{{- $h = $small.Height -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 <div class="wechat-share-thumb" style="position:absolute;width:0;height:0;overflow:hidden" aria-hidden="true">
-  <img src="{{ $thumb | absURL }}" alt="" width="1200" height="630" loading="eager" decoding="async" />
+  <img src="{{ $thumbURL }}" alt="" width="{{ $w }}" height="{{ $h }}" loading="lazy" fetchpriority="low" decoding="async" />
 </div>


### PR DESCRIPTION
针对日报 issue #257 的分析与修复。

## 根因分析：移动端 LCP 10-19s

issue 报告 `/zh/growth/posts/2025-annual-review/`（LCP 19.6s）与 `/ai-agent/posts/agent-identity-from-locke-to-openclaw/`（LCP 10.2s），PSI 提示 "Properly size images — savings 3960ms"。

排查发现可见封面早已有完整的 720w srcset + WebP 管线，**真正元凶是 `wechat-share-thumb.html`**：

```html
<img src=.../2025-annual-review.jpeg width=1200 height=630 loading=eager ...>
```

一个 0×0 隐藏容器里 `loading="eager"` 加载 **2048×1152 原图（810-850KB）**，且在 DOM 中排在可见封面之前，抢占全部带宽，直接把移动端 LCP 拖爆。

### 修复
微信抓图只需 ≥300px → 用 Hugo Pipes 生成 **640px 变体（~40KB，体积 -95%）**，并改为 `loading="lazy" fetchpriority="low"`。验证：

- ✅ 本地构建后两页的 thumb 均输出 640px 变体（40KB / 42KB）
- ✅ SVG 封面 / 无封面文章的 section OG 卡降级路径不变
- ✅ 页面上唯一 eager 图恢复为可见封面（fetchpriority=high）

## 附带修复：全站中文 `<title>` 假截断

`head.html` 用 `len`（**字节数**）判断是否 >50、用 `substr`（**rune 数**）截取——任何超过 50 字节的中文标题（约 17 个汉字以上）都被贴上假 "…" 后缀，文字其实并没截断。全站中文页面在 SERP 里的标题都带着无意义省略号。改用 `strings.RuneCount` 对齐单位。

修复前后（同一构建对比）：
```
前：<title>GoReleaser 教程：goreleaser.yaml 配置与发布自动化实战… | cubxxw</title>
后：<title>GoReleaser 教程：goreleaser.yaml 配置与发布自动化实战 | cubxxw</title>
```

## SEO 建议动作落地（issue 建议 1/2/3）

1. **go-release-tools（中英）标题/描述重写**：GSC 显示展现来自 goreleaser 配置类长尾查询（`name_template`、`prerelease`、release notes 等，排名 7-18），原标题 "Automate your software releases" 过泛。改为教程式标题并覆盖配置关键词；英文精确控制在 50 字符（title 截断上限）内。
2. **gpt-researcher（中英）meta description 强化**：排名 4.6 但 CTR 0%，描述加入 "ChatGPT Deep Research 的免费开源替代" 差异化钩子 + Docker 安装/真实成本等具体承诺。
3. **markItdown 大小写**：核实**无需改动**——`static/_redirects` 330-334 行已有 301 且线上验证生效（`curl -I` 返回 301），内容/数据中无大写残留内链，GSC 里旧 URL 的展现是索引残留，会随重抓自然收敛。

## 未动的项
- issue 建议 4/5（PSI 抓取失败、annual-review 是否持续回退）为观察项，等次日日报数据。
- `layouts/sitemap.xml` 工作区有一处先前会话遗留的未提交修改（image:caption 转义），未包含在本 PR。

Refs #257

https://claude.ai/code/session_01G14tGims1UPqnvkr4GLVLA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined GPT Researcher articles to highlight self-hosting, cited research reports, and ChatGPT Deep Research comparisons.
  * Updated GoReleaser article titles, keywords, and descriptions to better reflect their practical configuration and release automation guidance.

* **Bug Fixes**
  * Improved title truncation for Chinese and other multi-byte text, preventing unnecessary ellipses.
  * Improved WeChat sharing thumbnails with more reliable image selection, sizing, and loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->