### PR TITLE
fix(seo): 转义 sitemap image:caption 中的 & 等 XML 实体

### DIFF
--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -64,7 +64,11 @@
       <image:loc>{{ $imgURL }}</image:loc>
       <image:title>{{ $page.Title }}</image:title>
       {{- with $page.Params.cover.alt }}
-      <image:caption>{{ . | plainify }}</image:caption>
+      {{- /* plainify returns template.HTML (safe-marked), which defeats the
+             XML auto-escaping that image:title relies on — a raw & in alt text
+             then breaks the whole sitemap (Google: "parsing error", 0 pages).
+             printf "%s" casts back to a plain string so & → &amp; again. */ -}}
+      <image:caption>{{ . | plainify | printf "%s" }}</image:caption>
       {{- end }}
     </image:image>
     {{- end -}}


### PR DESCRIPTION
## 问题

GSC 报告 sitemap.xml **parsing error、Discovered pages 0** —— 整个 sitemap 无法被解析。

## 根因

`layouts/sitemap.xml` 里 `image:caption` 用了 `{{ . | plainify }}`。Hugo 的 `plainify` 返回 `template.HTML`(已标记为安全),这会**绕过 XML 模板的自动转义**。于是 `cover.alt` 中的裸 `&`(例如 "Wandering & Growing")原样输出,产生非法 XML,导致整个 sitemap 解析失败。

对比:`image:title` 直接输出 `$page.Title`(普通字符串),自动转义正常生效,所以只有 caption 出问题。

## 修复

`plainify` 之后接 `printf "%s"`,把 `template.HTML` 转回普通字符串,让 XML 自动转义重新生效(`&` → `&amp;`)。

## 验证

- 本地构建后 sitemap.xml 中 caption 输出 `&amp;`,XML 合法
- 合并部署后需在 GSC 重新提交 sitemap.xml,确认从 "1 error / 0 pages" 变为 "Success"

https://claude.ai/code/session_019v2yXMD6NM744PoRhtKqTD