### PR TITLE
fix(code): 移动端全屏代码块首字符不再被 overflow-x:clip 裁切

### DIFF
--- a/assets/css/extended/zzz-code-mobile.css
+++ b/assets/css/extended/zzz-code-mobile.css
@@ -62,6 +62,21 @@
     border-left: none !important;
     border-right: none !important;
   }
+
+  /* The full-bleed blocks overhang their column via the negative margins
+     above. But .post-content / .post-single carry `overflow-x: clip`
+     (custom.css US-017 mobile guard), whose clip edge is the column, not
+     the screen — so that overhang was being cut off. On the LEADING side
+     that clipped the first characters of every code line: at rest they
+     sat hidden, and a sideways drag only rubber-banded them into view
+     before snapping back under the clip. Let these two inner wrappers
+     show the overhang; the page-level guards (`.main` + `body`, both
+     still `overflow-x: clip` at the viewport edge) keep the page from
+     ever scrolling sideways. */
+  .post-content,
+  .post-single {
+    overflow-x: visible !important;
+  }
   .post-content pre code,
   .post-content .highlight pre code {
     /* 20px → 14px inner gutters + a slightly tighter type size:


### PR DESCRIPTION
## 问题

手机上打开带横向滚动的代码块，每行**开头的字符被遮住**，需要从左往右滑动才能把它拉出来，但松手后又回弹、重新被遮住。（见用户反馈截图：`name` 显示成 `me`、`colors` 显示成 `lors`、`---` 显示成 `-`。）

## 根因

不是滑动/回弹本身的问题，而是一处布局裁切：

- 移动端代码块用 `margin-left/right: calc(50% - 50vw)`（`zzz-code-mobile.css` §1）撑满屏幕，向正文列外"出血"。
- 但 `.post-content` / `.post-single` 上带着 `overflow-x: clip`（`custom.css` 的 US-017 移动端溢出兜底），它的裁切边是**正文列**而非**屏幕边**，于是这段出血被裁掉。
- 在**起始一侧**，裁掉的正好是每行代码的头几个字符：静止时（`scrollLeft:0`）首字符被遮住；用户横滑时靠 overscroll 回弹短暂露出，松手回弹到 0 又被重新裁掉——即"拉出来又缩回去"。

该裁切与滚动位置、`mask` 提示层均无关，是纯布局问题，在 Chromium 与 iOS Safari 上都能复现。

## 修复

在 `≤600px` 断点（全屏出血生效的范围）让这两个内层容器显示出血内容：

```css
.post-content,
.post-single { overflow-x: visible !important; }
```

页面级兜底 `.main` 与 `body` **仍保持** `overflow-x: clip`（裁切边在视口边缘），因此页面依旧不会横向滚动。行尾一侧的滚动留白（#253）不受影响。

## 验证（无头 Chromium，375–390px 视口，忠实链接真实 CSS/JS）

- ✅ 行首字符（`---` / `name:` / `colors:` …）静止时完整可见，无需滑动
- ✅ 行尾字符滚到末尾仍完整可见（#253 保持）
- ✅ 代码块仍满屏出血（`hl_left:0 / hl_right:390`）
- ✅ 页面无横向滚动（`document.scrollWidth == innerWidth`）
- ✅ 列表内嵌代码块渲染正常，无回归
- ✅ 桌面端（>600px）不受影响（改动仅在 `≤600px` 断点内）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARRnXbaFePtcaL3Fzi41wm

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARRnXbaFePtcaL3Fzi41wm)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile code blocks being clipped at the left and right edges.
  * Code lines now display their full content without requiring horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->