### PR TITLE
perf(css): 页面级 CSS 从全站包拆出按页加载（日报 #260 "Reduce unused CSS"）

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -77,10 +77,32 @@
 
 {{- /* order is important */}}
 {{- $core := (slice $theme_vars $reset $common $hljs $includes_all $media) | resources.Concat "assets/css/core.css" | resources.Minify }}
-{{- /* homepage-daypage.css (~52 KB) is homepage-only — keep it out of the
-       site-wide bundle and load it separately on the home pages below. */}}
+{{- /* Page-scoped extended CSS: files whose (uniquely namespaced) selectors
+       render on exactly one page or section are pulled OUT of the site-wide
+       bundle and loaded only where they apply — the same split already used
+       for homepage-daypage.css. Every other page then stops shipping this
+       CSS as dead weight (Lighthouse "Reduce unused CSS").
+
+         homepage-daypage.css (~52 KB, .hp-*)  → home only
+         zzz-travel-world.css  (~38 KB, .tw-*)  → travel page only
+         products.css          (~32 KB, .osx-*) → /projects/ landing only
+         section-growth.css    (~15 KB, .gr-*)  → /growth/ landing only
+
+       These three (.tw-/.osx-/.gr-) are provably independent of the
+       load-bearing hover/press cascade documented in zzz-hover-touch-reset.css
+       ("source hover < reset < press-feedback"): that layer, and every other
+       bundled file, only ever target the .hp-/.eig-/.eip-/.eitr-/.aia-/.oss-/
+       .about-/.eng-/.column- families — never .tw-/.osx-/.gr-. So loading
+       them after the main bundle changes no existing cascade outcome. Files
+       whose classes DO appear in that layer (about.css, section-ai-agent.css,
+       section-engineering.css, columns.css) are deliberately left in the
+       bundle to preserve that order. */}}
 {{- $homepageCSS := resources.Get "css/extended/homepage-daypage.css" }}
-{{- $extendedFiles := collections.Complement (slice $homepageCSS) (resources.Match "css/extended/*.css") }}
+{{- $travelCSS   := resources.Get "css/extended/zzz-travel-world.css" }}
+{{- $projectsCSS := resources.Get "css/extended/products.css" }}
+{{- $growthCSS   := resources.Get "css/extended/section-growth.css" }}
+{{- $pageScoped  := (slice $homepageCSS $travelCSS $projectsCSS $growthCSS) }}
+{{- $extendedFiles := collections.Complement $pageScoped (resources.Match "css/extended/*.css") }}
 {{- $extended := $extendedFiles | resources.Concat "assets/css/extended.css" | resources.Minify }}
 
 {{- /* bundle all required css */}}
@@ -94,16 +116,21 @@
 <link crossorigin="anonymous" href="{{ $stylesheet.RelPermalink }}" rel="preload stylesheet" as="style">
 {{- end }}
 
-{{- /* Homepage-only DayPage stylesheet (split out of the global bundle
-       above). Loaded after it, so its rules keep the same cascade
-       priority they had when concatenated. */}}
-{{- if .IsHome }}
-{{- $hp := $homepageCSS | resources.Minify }}
+{{- /* Page-scoped stylesheets split out of the global bundle above, each
+       loaded only where its selectors render and after the main bundle, so
+       its rules keep the same cascade priority they had when concatenated. */}}
+{{- $conditionalCSS := slice }}
+{{- if .IsHome }}{{ $conditionalCSS = $conditionalCSS | append $homepageCSS }}{{ end }}
+{{- if eq .Layout "travel" }}{{ $conditionalCSS = $conditionalCSS | append $travelCSS }}{{ end }}
+{{- if and (eq .Kind "section") (eq .Section "projects") }}{{ $conditionalCSS = $conditionalCSS | append $projectsCSS }}{{ end }}
+{{- if and (eq .Kind "section") (eq .Section "growth") }}{{ $conditionalCSS = $conditionalCSS | append $growthCSS }}{{ end }}
+{{- range $conditionalCSS }}
+{{- $c := . | resources.Minify }}
 {{- if not site.Params.assets.disableFingerprinting }}
-{{- $hp = $hp | fingerprint }}
-<link crossorigin="anonymous" href="{{ $hp.RelPermalink }}" integrity="{{ $hp.Data.Integrity }}" rel="preload stylesheet" as="style">
+{{- $c = $c | fingerprint }}
+<link crossorigin="anonymous" href="{{ $c.RelPermalink }}" integrity="{{ $c.Data.Integrity }}" rel="preload stylesheet" as="style">
 {{- else }}
-<link crossorigin="anonymous" href="{{ $hp.RelPermalink }}" rel="preload stylesheet" as="style">
+<link crossorigin="anonymous" href="{{ $c.RelPermalink }}" rel="preload stylesheet" as="style">
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
## 背景

站点日报 [#260](https://github.com/cubxxw/blog/issues/260) 的 Lighthouse 部分，**几乎每一个 URL 都报 "Reduce unused CSS"（150–550ms）**。根因是 `layouts/partials/head.html` 把 `assets/css/extended/*.css`（未压缩合计约 976KB）用 `resources.Concat` 拼成单个全站 `stylesheet.css`，其中不少文件的选择器只在某一个页面/栏目出现，却被压在每个页面上一起下发。

`homepage-daypage.css`（约 52KB，`.hp-*`，仅首页）此前已经用「拆出全站包 + 按页加载」的方式处理过。本 PR 沿用同一套做法，把另外三个**同样页面级、且互不影响级联**的文件也拆出去。

## 改动

仅改 `layouts/partials/head.html`（+38 / −11）：把下面三个文件排除出全站包，改为仅在对应页面追加加载。

| 文件 | 类名前缀 | 加载条件 |
| --- | --- | --- |
| `zzz-travel-world.css` (~38KB) | `.tw-` | `eq .Layout "travel"` |
| `products.css` (~32KB) | `.osx-` | `/projects/` 落地页（`Kind=section`） |
| `section-growth.css` (~15KB) | `.gr-` | `/growth/` 落地页（`Kind=section`） |

### 为什么安全（零级联回归）

`zzz-hover-touch-reset.css` 里注释明确记录了一条 load-bearing 顺序：`source hover < reset < press-feedback`。逐一核对后：

- 这条级联层、以及全站其它任何 CSS（`zz-dark-reading` / `zzz-*` / `custom.css`）**从不引用** `.tw-` / `.osx-` / `.gr-`——它们只针对 `.hp-/.eig-/.eip-/.eitr-/.aia-/.oss-/.about-/.eng-/.column-` 家族。所以把这三个文件放到主包**之后**加载，不会改变任何既有级联结果。
- 会被那条级联层引用的 `about.css` / `section-ai-agent.css` / `section-engineering.css` / `columns.css` **刻意保留在主包内**，以维持原顺序。

`.tw-/.osx-/.gr-` 标记也确认只由这三个模板消费（travel 页模板、`section/projects.html`、`section/growth.html`），不出现在分类文章页上。

## 效果

除 travel / projects / growth 三个落地页外的**每个页面**（首页、about、各分类文章等）少下发约 **64KB（minified）** 无用 CSS。

## 验证

本地用 hugo `0.145.0` 构建全站（599 页，`exit 0`）后逐项核对：

- 文章页、about 页 → 仅引主包，无额外 CSS
- travel / projects / growth 落地页 → 各自在主包后追加对应拆分文件
- 主包中已 **不含** `.tw-tome` / `.osx-window` / `.gr-timeline`（各 0 处）
- 主包中仍保留 `.about-card` / `.aia-featured`（各 3 处）
- growth **文章页**不加载 `section-growth.css`
- 首页行为与改动前一致（仍追加 `homepage-daypage.css`）

> 说明：SEO 部分本轮各 URL 均为 100 分；日报里的高 LCP 主要是移动端单次跑分（`numberOfRuns: 1`）+ 冷缓存的抖动，图片管线（响应式 WebP + width/height）已到位，故本 PR 聚焦在可系统性收敛的 "Reduce unused CSS"。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDoD7AQhMrFeDPTToYiSJn)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved stylesheet loading by serving page-specific styles only where needed.
  * Added optimized preloading for conditional styles, including integrity verification when fingerprinting is enabled.
  * Maintained a global stylesheet bundle for shared styles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->