### PR TITLE
Fix Buttondown newsletter tag filters

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -53,6 +53,9 @@ jobs:
         with:
           node-version: 22
 
+      - name: Test newsletter integration
+        run: npm run newsletter:test
+
       - name: Wait for deploy to propagate (push runs only)
         if: github.event_name == 'push'
         run: |

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "covers": "node --env-file-if-exists=.env scripts/generate-covers.mjs",
     "covers:write": "node --env-file-if-exists=.env scripts/generate-covers.mjs --write",
     "covers:test": "node --test scripts/generate-covers.test.mjs",
+    "newsletter:test": "node --test scripts/buttondown-tags.test.mjs",
     "mcp:server": "node scripts/mcp-server.mjs",
     "baidu:push": "node scripts/baidu-push.mjs",
     "baidu:push:all": "node scripts/baidu-push.mjs --all",

--- a/scripts/buttondown-tags.test.mjs
+++ b/scripts/buttondown-tags.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  buildSubscriberTagFilter,
+  fetchButtondownTagIds,
+  resolveButtondownTagIds,
+} from './lib/buttondown-tags.mjs';
+
+const tags = [
+  { id: 'sub_tag_zh', name: 'lang:zh' },
+  { id: 'sub_tag_en', name: 'lang:en' },
+];
+
+test('resolves human-readable tag names to Buttondown identifiers', () => {
+  assert.deepEqual(
+    resolveButtondownTagIds(tags, ['lang:zh', 'lang:en']),
+    { 'lang:zh': 'sub_tag_zh', 'lang:en': 'sub_tag_en' },
+  );
+});
+
+test('rejects missing and duplicate tags instead of widening the audience', () => {
+  assert.throws(
+    () => resolveButtondownTagIds(tags, ['lang:missing']),
+    /does not exist/,
+  );
+  assert.throws(
+    () => resolveButtondownTagIds([...tags, tags[0]], ['lang:zh']),
+    /duplicated/,
+  );
+});
+
+test('fetches tags with authentication and returns identifiers', async () => {
+  let request;
+  const result = await fetchButtondownTagIds({
+    token: 'test-token',
+    requiredNames: ['lang:zh', 'lang:en'],
+    fetchImpl: async (url, options) => {
+      request = { url, options };
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { count: tags.length, results: tags };
+        },
+      };
+    },
+  });
+
+  assert.match(request.url, /\/v1\/tags\?page_size=100$/);
+  assert.equal(request.options.headers.Authorization, 'Token test-token');
+  assert.deepEqual(result, { 'lang:zh': 'sub_tag_zh', 'lang:en': 'sub_tag_en' });
+});
+
+test('builds an audience filter with the resolved identifier', () => {
+  assert.deepEqual(buildSubscriberTagFilter('sub_tag_zh'), {
+    predicate: 'and',
+    filters: [
+      {
+        field: 'subscriber.tags',
+        operator: 'contains',
+        value: 'sub_tag_zh',
+      },
+    ],
+    groups: [],
+  });
+});
+
+test('surfaces Buttondown lookup failures', async () => {
+  await assert.rejects(
+    fetchButtondownTagIds({
+      token: 'test-token',
+      requiredNames: ['lang:zh'],
+      fetchImpl: async () => ({
+        ok: false,
+        status: 403,
+        async json() {
+          return { detail: 'Forbidden' };
+        },
+      }),
+    }),
+    /lookup failed \(403\)/,
+  );
+});

--- a/scripts/lib/buttondown-tags.mjs
+++ b/scripts/lib/buttondown-tags.mjs
@@ -1,0 +1,60 @@
+const TAGS_API = 'https://api.buttondown.com/v1/tags?page_size=100';
+
+export function resolveButtondownTagIds(tags, requiredNames) {
+  if (!Array.isArray(tags)) {
+    throw new Error('Buttondown tags response is missing a results array.');
+  }
+
+  return Object.fromEntries(requiredNames.map((name) => {
+    const matches = tags.filter((tag) => tag?.name === name);
+    if (matches.length === 0) {
+      throw new Error(`Buttondown tag "${name}" does not exist.`);
+    }
+    if (matches.length > 1) {
+      throw new Error(`Buttondown tag "${name}" is duplicated; expected exactly one match.`);
+    }
+
+    const id = matches[0]?.id;
+    if (typeof id !== 'string' || id.length === 0) {
+      throw new Error(`Buttondown tag "${name}" has no valid identifier.`);
+    }
+
+    return [name, id];
+  }));
+}
+
+export async function fetchButtondownTagIds({ token, requiredNames, fetchImpl = fetch }) {
+  const response = await fetchImpl(TAGS_API, {
+    headers: { Authorization: `Token ${token}` },
+  });
+  const body = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(`Buttondown tags lookup failed (${response.status}): ${JSON.stringify(body).slice(0, 300)}`);
+  }
+
+  const results = body.results;
+  if (Number.isFinite(body.count) && body.count > (results?.length || 0)) {
+    throw new Error(`Buttondown returned only ${results?.length || 0} of ${body.count} tags; refusing an incomplete lookup.`);
+  }
+
+  return resolveButtondownTagIds(results, requiredNames);
+}
+
+export function buildSubscriberTagFilter(tagId) {
+  if (typeof tagId !== 'string' || tagId.length === 0) {
+    throw new Error('A Buttondown tag identifier is required.');
+  }
+
+  return {
+    predicate: 'and',
+    filters: [
+      {
+        field: 'subscriber.tags',
+        operator: 'contains',
+        value: tagId,
+      },
+    ],
+    groups: [],
+  };
+}

--- a/scripts/newsletter-send.mjs
+++ b/scripts/newsletter-send.mjs
@@ -24,14 +24,18 @@
 // State: config/newsletter-state.json (committed) — { sent: { url: {at, id} } }
 
 import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import {
+  buildSubscriberTagFilter,
+  fetchButtondownTagIds,
+} from './lib/buttondown-tags.mjs';
 
 const SITE = 'https://cubxxw.com';
 const API = 'https://api.buttondown.com/v1/emails';
 const STATE_PATH = new URL('../config/newsletter-state.json', import.meta.url).pathname;
 
 const FEEDS = {
-  zh: { url: `${SITE}/zh/index.xml`, tag: 'lang:zh', readMore: '继续阅读全文 →', footer: `你收到这封信，是因为你在 [cubxxw.com](${SITE}/zh/) 订阅了新文章通知。` },
-  en: { url: `${SITE}/index.xml`, tag: 'lang:en', readMore: 'Continue reading →', footer: `You are receiving this because you subscribed to new-post updates on [cubxxw.com](${SITE}/).` },
+  zh: { url: `${SITE}/zh/index.xml`, tagName: 'lang:zh', readMore: '继续阅读全文 →', footer: `你收到这封信，是因为你在 [cubxxw.com](${SITE}/zh/) 订阅了新文章通知。` },
+  en: { url: `${SITE}/index.xml`, tagName: 'lang:en', readMore: 'Continue reading →', footer: `You are receiving this because you subscribed to new-post updates on [cubxxw.com](${SITE}/).` },
 };
 
 const args = process.argv.slice(2);
@@ -48,9 +52,15 @@ const RECENT_DAYS = parseInt(val('--recent', '7'), 10);
 const MAX_PER_RUN = parseInt(val('--max', '3'), 10);
 const RESEND_URL = val('--resend', null);
 const TOKEN = process.env.BUTTONDOWN_API_KEY;
+const feedKeys = FEED_SEL === 'all' ? Object.keys(FEEDS) : [FEED_SEL];
+let tagIdsByName = {};
 
 if (!['draft', 'send'].includes(MODE)) {
   console.error(`❌ --mode must be draft|send, got "${MODE}"`);
+  process.exit(1);
+}
+if (feedKeys.some((key) => !FEEDS[key])) {
+  console.error('❌ --feed must be zh|en|all');
   process.exit(1);
 }
 if (!TOKEN && !DRY_RUN) {
@@ -119,27 +129,18 @@ function buildBody(item, feed) {
 }
 
 async function createEmail(item, feed) {
+  const tagId = tagIdsByName[feed.tagName] || `dry-run:${feed.tagName}`;
   const payload = {
     subject: item.title,
     body: buildBody(item, feed),
     status: MODE === 'send' ? 'about_to_send' : 'draft',
     // Buttondown removed included_tags/excluded_tags from the email schema.
     // Audience targeting now uses a filter group.
-    filters: {
-      predicate: 'and',
-      filters: [
-        {
-          field: 'subscriber.tags',
-          operator: 'contains',
-          value: feed.tag,
-        },
-      ],
-      groups: [],
-    },
+    filters: buildSubscriberTagFilter(tagId),
     metadata: { source: 'newsletter-send', post_url: item.link },
   };
   if (DRY_RUN) {
-    console.log(`  [dry-run] would create ${payload.status} email "${item.title}" → tag ${feed.tag}`);
+    console.log(`  [dry-run] would create ${payload.status} email "${item.title}" → tag ${feed.tagName}`);
     return { id: 'dry-run' };
   }
   const res = await fetch(API, {
@@ -155,13 +156,23 @@ async function createEmail(item, feed) {
 }
 
 /* ── main ── */
+// GitHub dry-runs still receive the API token, so they validate the real tag
+// lookup without creating an email. Tokenless local dry-runs use placeholders.
+if (TOKEN) {
+  try {
+    tagIdsByName = await fetchButtondownTagIds({
+      token: TOKEN,
+      requiredNames: feedKeys.map((key) => FEEDS[key].tagName),
+    });
+    console.log(`🏷️  Resolved Buttondown audience tags: ${feedKeys.map((key) => FEEDS[key].tagName).join(', ')}`);
+  } catch (error) {
+    console.error(`❌ Buttondown tag preflight failed: ${error.message}`);
+    process.exit(1);
+  }
+}
+
 const now = Date.now();
 const windowMs = RECENT_DAYS * 24 * 3600 * 1000;
-const feedKeys = FEED_SEL === 'all' ? Object.keys(FEEDS) : [FEED_SEL];
-if (feedKeys.some((k) => !FEEDS[k])) {
-  console.error(`❌ --feed must be zh|en|all`);
-  process.exit(1);
-}
 
 let state = loadState();
 const bootstrap = state === null;


### PR DESCRIPTION
## What changed

- Resolve Buttondown audience tag names to their real API identifiers before creating newsletter emails.
- Fail fast when a required tag is missing, duplicated, or malformed so the audience can never silently widen.
- Add focused integration tests and run them in the newsletter GitHub Actions workflow.
- Keep dry-run validation side-effect free while still checking the real Buttondown tag configuration when credentials are available.

## Root cause

The newsletter script sent human-readable values such as `lang:zh` and `lang:en` in the email audience filter. Buttondown requires tag identifiers there, so every request failed with HTTP 422: `Tag filters must be valid tag identifiers.`

## Validation

- `npm run newsletter:test` — 5/5 passed.
- Local Chinese and English feed dry-runs passed.
- GitHub Actions dry-run 30429131003 passed using the repository secret and resolved both production audience tags, without creating or sending emails.