### PR TITLE
Fix Netlify deployment and E2E CI failures

### DIFF
--- a/content/en/ai-agent/posts/UFO.md
+++ b/content/en/ai-agent/posts/UFO.md
@@ -16,7 +16,6 @@ tags:
   - Automation
   - Development
   - Open Source
-  - Windows
 categories:
   - Development
 description: >

--- a/content/en/ai-agent/posts/ai-recommend.md
+++ b/content/en/ai-agent/posts/ai-recommend.md
@@ -12,7 +12,6 @@ tags:
   - AI
   - LLM
   - RAG
-  - Performance
   - Monitoring
   - Project Learning
 categories:

--- a/content/en/ai-agent/posts/independent-developer.md
+++ b/content/en/ai-agent/posts/independent-developer.md
@@ -9,7 +9,6 @@ type: posts
 author: ["Xinwei Xiong", "Me"]
 keywords: []
 tags:
-  - Indie Hacker
   - Solo Builder
   - Product Strategy
   - Development

--- a/content/zh/ai-agent/posts/UFO.md
+++ b/content/zh/ai-agent/posts/UFO.md
@@ -20,7 +20,7 @@ tags:
   - AI
   - Agent
   - Automation
-  - Windows
+  - Development
   - MCP
   - Open Source
   - Project Learning

--- a/content/zh/ai-agent/posts/independent-developer.md
+++ b/content/zh/ai-agent/posts/independent-developer.md
@@ -9,7 +9,6 @@ type: posts
 author: ["Xinwei Xiong", "Me"]
 keywords: []
 tags:
-  - Indie Hacker
   - Solo Builder
   - Product Strategy
   - Development

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,7 +23,9 @@
   HUGO_VERSION = "0.145.0"
   HUGO_EXTENDED = "true"
   SECRETS_SCAN_OMIT_PATHS = ".obsidian/**"
-  SECRETS_SCAN_OMIT_KEYS = "DASHSCOPE_BASE_URL"
+  # Public service endpoints are configuration, not credentials. Keep secret
+  # scanning enabled for actual API keys while avoiding URL false positives.
+  SECRETS_SCAN_OMIT_KEYS = "DASHSCOPE_BASE_URL,OPENAI_BASE_URL"
   GIT_SUBMODULE_STRATEGY = "recursive"
 
 [context.production.environment]

--- a/tests/e2e/us029-typography.spec.ts
+++ b/tests/e2e/us029-typography.spec.ts
@@ -4,6 +4,8 @@ import * as fs from 'fs';
 
 const EN_URL = 'http://localhost:1313/engineering/posts/use-go-tools-dlv/';
 const ZH_URL = 'http://localhost:1313/zh/engineering/posts/use-go-tools-dlv/';
+const EN_DROPCAP_URL = 'http://localhost:1313/growth/posts/friction-is-growth/';
+const ZH_DROPCAP_URL = 'http://localhost:1313/zh/growth/posts/friction-is-growth/';
 
 const SNAPSHOTS_DIR = path.join(__dirname, '__screenshots__', 'us029');
 
@@ -80,7 +82,7 @@ test('EN: post-description is italic', async ({ page }) => {
 // EN: first paragraph has drop-cap class
 test('EN: first paragraph has drop-cap class', async ({ page }) => {
   await page.setViewportSize({ width: 1680, height: 1050 });
-  await page.goto(EN_URL);
+  await page.goto(EN_DROPCAP_URL);
   const firstP = page.locator('.post-content p.drop-cap');
   await expect(firstP).toHaveCount(1);
 });
@@ -88,7 +90,7 @@ test('EN: first paragraph has drop-cap class', async ({ page }) => {
 // ZH: first paragraph has drop-cap class
 test('ZH: first paragraph has drop-cap class', async ({ page }) => {
   await page.setViewportSize({ width: 1680, height: 1050 });
-  await page.goto(ZH_URL);
+  await page.goto(ZH_DROPCAP_URL);
   const firstP = page.locator('.post-content p.drop-cap');
   await expect(firstP).toHaveCount(1);
 });


### PR DESCRIPTION
## Root causes

1. Netlify production rejected five non-canonical article tags during `content-check`.
2. Typography E2E coverage still expected drop caps on engineering articles after the layout intentionally limited the default to growth/travel articles.
3. Netlify Secrets Scanner treated the public `OPENAI_BASE_URL` endpoint as a secret because the same URL appears in the UFO article.

## Fixes

- normalize or remove the five invalid/duplicate tags reported by Netlify
- run drop-cap E2E assertions against current growth articles in both languages
- add `OPENAI_BASE_URL` to `SECRETS_SCAN_OMIT_KEYS`, alongside the existing public `DASHSCOPE_BASE_URL` exception, while keeping scanning enabled for actual API keys

## Validation

- `node scripts/normalize-tags.mjs --check`
- `make production-build`
- local targeted drop-cap Playwright tests: 4 passed
- local CI-like E2E suite: 157 passed, 8 skipped, 1 unrelated retry recovered
- GitHub Build: passed
- GitHub E2E: passed (7m11s)
- Netlify Deploy Preview: ready
- Netlify branch deploy: ready
- Netlify Header rules and Redirect rules: passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated English and Chinese AI Agent article tags for improved categorization.
  - Replaced the Windows tag with Development in the Chinese UFO article.
  - Removed outdated Performance and Indie Hacker tags from relevant articles.

- **Bug Fixes**
  - Improved typography page coverage for English and Chinese drop-cap layouts.
  - Refined deployment configuration to prevent false positives during secret scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->