### PR TITLE
Refine About page as a public practice archive

### DIFF
--- a/assets/css/about-calibration.css
+++ b/assets/css/about-calibration.css
@@ -32,46 +32,77 @@
 .studio-hero__viewport {
   position: relative;
   height: min(620px, 52vw);
-  perspective: 1200px;
+  isolation: isolate;
+}
+
+.studio-hero__viewport::before {
+  position: absolute;
+  inset: 34px -18px 18px 42px;
+  z-index: -1;
+  border-radius: 28px;
+  background:
+    linear-gradient(145deg,
+      color-mix(in srgb, var(--studio-accent) 9%, var(--color-paper)),
+      color-mix(in srgb, var(--color-ink) 5%, var(--color-paper)));
+  box-shadow: 0 34px 80px -58px color-mix(in srgb, var(--color-ink) 72%, transparent);
+  content: "";
 }
 
 .studio-hero__visual {
   position: absolute;
-  inset: 0 0 auto auto;
-  width: 90%;
+  inset: 0 0 0 auto;
+  width: 92%;
+  height: 100%;
   margin: 0;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, white 38%, transparent);
+  border-radius: 24px;
+  background: var(--color-paper);
   opacity: 0;
   visibility: hidden;
-  transform-origin: 85% 85%;
-  transition: transform 220ms cubic-bezier(.2, .76, .2, 1), opacity 140ms ease, visibility 0s linear 220ms;
+  transform-origin: center;
+  transition:
+    transform 320ms cubic-bezier(.2, .76, .2, 1),
+    opacity 220ms ease,
+    visibility 0s linear 320ms;
+}
+
+.studio-hero__visual::before {
+  display: none;
 }
 
 .studio-hero__visual[data-hero-position="active"] {
   z-index: 3;
   opacity: 1;
   visibility: visible;
-  transform: rotate(1deg) translate3d(0, 0, 0);
+  transform: translate3d(0, 0, 0);
   transition-delay: 0s;
+  box-shadow:
+    0 32px 72px -44px color-mix(in srgb, var(--color-ink) 82%, transparent),
+    0 2px 12px color-mix(in srgb, var(--color-ink) 10%, transparent);
   will-change: transform, opacity;
 }
 
 .studio-hero__visual[data-hero-position="next"] {
   z-index: 2;
-  opacity: .42;
-  visibility: visible;
-  transform: rotate(4deg) translate3d(18px, 6px, -60px) scale(.96);
-  transition-delay: 0s;
-  will-change: transform, opacity;
+  opacity: 0;
+  visibility: hidden;
+  transform: scale(.992);
 }
 
 .studio-hero__visual[data-hero-position="prev"] {
   z-index: 1;
   opacity: 0;
-  transform: rotate(-5deg) translate3d(-24px, 12px, -100px) scale(.92);
+  transform: translate3d(-12px, 0, 0) scale(.985);
 }
 
 .studio-hero__visual img {
+  width: 100%;
+  height: 100%;
+  max-height: none;
+  aspect-ratio: auto;
   object-position: 32% center;
+  border-radius: 0;
   filter: none;
 }
 
@@ -84,8 +115,27 @@
 }
 
 .studio-hero__visual figcaption {
-  min-height: 54px;
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: grid;
+  gap: 4px;
+  box-sizing: border-box;
+  min-height: 108px;
+  margin: 0;
+  padding: 48px 24px 20px;
+  color: rgba(255, 255, 255, .86);
+  background: linear-gradient(to bottom, transparent, rgba(10, 10, 10, .72));
+  font-size: .74rem;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, .4);
   transition: opacity 180ms ease;
+}
+
+.studio-hero__visual figcaption span {
+  color: #fff;
+  font-size: .68rem;
+  letter-spacing: .06em;
 }
 
 .studio-hero__visual:not([data-hero-position="active"]) figcaption {
@@ -95,21 +145,29 @@
 
 .studio-hero__controls {
   position: absolute;
-  right: 0;
-  top: 18px;
+  right: 14px;
+  top: 14px;
   bottom: auto;
   z-index: 5;
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 2px;
+  padding: 5px;
+  border: 1px solid rgba(255, 255, 255, .45);
+  border-radius: 999px;
+  background: rgba(248, 248, 246, .76);
+  box-shadow: 0 10px 28px -20px rgba(0, 0, 0, .7);
+  backdrop-filter: blur(18px) saturate(1.2);
+  -webkit-backdrop-filter: blur(18px) saturate(1.2);
 }
 
 .studio-hero__controls > span {
-  margin-right: 5px;
-  color: white;
-  text-shadow: 0 1px 8px rgba(0, 0, 0, .55);
+  min-width: 52px;
+  margin: 0 2px 0 8px;
+  color: #252525;
+  text-shadow: none;
   font-family: var(--font-mono);
-  font-size: .65rem;
+  font-size: .62rem;
   font-weight: 700;
   letter-spacing: .1em;
 }
@@ -117,21 +175,20 @@
 .studio-hero__controls button {
   display: inline-grid;
   place-items: center;
-  width: 44px;
-  height: 44px;
+  width: 38px;
+  height: 38px;
   padding: 0;
-  border: 1px solid rgba(255, 255, 255, .62);
+  border: 0;
   border-radius: 50%;
   color: #171717;
-  background: rgba(255, 255, 255, .88);
-  backdrop-filter: blur(10px);
+  background: transparent;
   cursor: pointer;
-  transition: transform 200ms ease, border-color 200ms ease;
+  transition: transform 180ms ease, background 180ms ease;
 }
 
 .studio-hero__controls button:hover {
-  border-color: var(--color-ink);
-  transform: translateY(-2px);
+  background: rgba(255, 255, 255, .82);
+  transform: scale(1.04);
 }
 
 .studio-hero__controls button:focus-visible {
@@ -150,97 +207,274 @@
 
 html[lang="zh"] .studio-hero h1 {
   max-width: 650px;
-  font-size: clamp(3rem, 4.7vw, 4.7rem);
+  font-size: clamp(3rem, 4vw, 4.5rem);
 }
 
-.studio-manifesto h2 {
-  max-width: 720px;
-  font-size: clamp(2.3rem, 3.45vw, 3.45rem);
-  line-height: 1.12;
+.studio-archive {
+  padding: clamp(72px, 9vw, 112px) 0;
+  border-top: 1px solid var(--color-rule);
 }
 
-.studio-manifesto {
-  grid-template-columns: 1fr;
-}
-
-.studio-manifesto__content {
+.studio-archive__intro {
   display: grid;
-  align-content: center;
-  width: min(100%, 980px);
-  margin-inline: auto;
+  grid-template-columns: minmax(0, 1.45fr) minmax(260px, .55fr);
+  gap: clamp(32px, 7vw, 104px);
+  align-items: end;
 }
 
-.studio-manifesto__loop {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr auto 1fr;
-  gap: clamp(10px, 2vw, 24px);
-  align-items: center;
-  margin-top: clamp(42px, 7vw, 74px);
-}
-
-.studio-manifesto__loop button {
-  display: block;
-  min-height: 90px;
-  padding: 18px 4px;
-  border: 0;
-  border-bottom: 1px solid var(--color-rule);
-  border-radius: 0;
-  color: var(--color-ink-muted);
-  background: transparent;
-  font-family: var(--font-display);
-  font-size: clamp(1.65rem, 3vw, 2.7rem);
-  font-weight: 600;
-  text-align: left;
-  cursor: pointer;
-  transition: transform 180ms ease, color 180ms ease, border-color 180ms ease;
-}
-
-.studio-manifesto__loop button::before {
-  display: block;
-  margin-bottom: 10px;
-  color: var(--studio-accent);
-  font-family: var(--font-mono);
-  font-size: .65rem;
-  font-weight: 600;
-  letter-spacing: .08em;
-  content: attr(data-step);
-}
-
-.studio-manifesto__loop button[aria-pressed="true"] {
-  color: var(--studio-accent);
-  border-color: var(--studio-accent);
-  background: transparent;
-  transform: translateY(-3px);
-}
-
-.studio-manifesto__loop button:hover {
-  border-color: var(--color-ink);
-}
-
-.studio-manifesto__loop button:focus-visible {
-  outline: 2px solid var(--studio-accent);
-  outline-offset: 3px;
-}
-
-.studio-manifesto__loop > i {
-  color: var(--color-ink-muted);
-  font-family: var(--font-mono);
-  font-size: 1rem;
-  font-style: normal;
-}
-
-.studio-manifesto__insight,
-.studio-manifesto div > p.studio-manifesto__insight {
-  min-height: 1.5em;
-  margin: clamp(30px, 5vw, 52px) 0 0;
+.studio-archive__intro h2 {
+  max-width: 820px;
+  margin: 0;
   color: var(--color-ink);
-  font-family: var(--font-prose);
-  font-size: clamp(1.25rem, 2vw, 1.85rem);
-  line-height: 1.45;
+  font-family: var(--font-display);
+  font-size: clamp(2.35rem, 3.65vw, 3.65rem);
+  font-weight: 600;
+  line-height: 1.08;
+  letter-spacing: -.045em;
+  text-wrap: balance;
 }
 
-html[lang="zh"] .studio-manifesto h2 {
-  font-size: clamp(2.25rem, 3.5vw, 3.45rem);
+html[lang="zh"] .studio-archive__intro h2 {
+  font-size: clamp(2.25rem, 3.45vw, 3.45rem);
+  line-height: 1.18;
+}
+
+.studio-archive__intro > p {
+  max-width: 34ch;
+  margin: 0 0 .25em;
+  color: var(--color-ink-muted);
+  font-family: var(--font-prose);
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.studio-archive__map {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: clamp(46px, 7vw, 78px);
+}
+
+.studio-archive__axis {
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  min-height: 310px;
+  padding: clamp(26px, 3.2vw, 38px);
+  border: 1px solid var(--color-rule);
+  border-radius: var(--studio-radius);
+}
+
+.studio-archive__axis--practice {
+  grid-column: span 7;
+  background:
+    radial-gradient(circle at 92% 10%, color-mix(in srgb, var(--studio-accent) 12%, transparent), transparent 34%),
+    color-mix(in srgb, var(--color-paper) 96%, var(--studio-accent));
+}
+
+.studio-archive__axis--thought {
+  grid-column: span 5;
+  background: color-mix(in srgb, var(--color-paper) 95%, var(--color-ink));
+}
+
+.studio-archive__axis > p {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 20px;
+  margin: 0;
+  color: var(--studio-accent);
+  font-family: var(--font-mono);
+  font-size: .7rem;
+  font-weight: 750;
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+
+.studio-archive__axis > p b {
+  color: var(--color-ink-muted);
+  font-size: .72rem;
+  font-weight: 650;
+}
+
+.studio-archive__axis h3 {
+  max-width: 19ch;
+  margin: auto 0 clamp(28px, 4vw, 46px);
+  color: var(--color-ink);
+  font-family: var(--font-display);
+  font-size: clamp(1.55rem, 2.3vw, 2.25rem);
+  font-weight: 590;
+  line-height: 1.2;
+  letter-spacing: -.035em;
+}
+
+html[lang="zh"] .studio-archive__axis h3 {
+  max-width: 16ch;
+  line-height: 1.35;
+}
+
+.studio-archive__axis nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.studio-archive__axis nav a,
+.studio-archive__axis-link {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--color-rule);
+  border-radius: 999px;
+  color: var(--color-ink);
+  background: color-mix(in srgb, var(--color-paper) 80%, transparent);
+  font-family: var(--font-meta);
+  font-size: .76rem;
+  font-weight: 650;
+  text-decoration: none;
+  transition: color 160ms ease, border-color 160ms ease, background 160ms ease;
+}
+
+.studio-archive__axis nav a:hover,
+.studio-archive__axis-link:hover {
+  color: var(--color-paper);
+  border-color: var(--studio-accent);
+  background: var(--studio-accent);
+}
+
+.studio-archive__axis-link {
+  align-self: flex-start;
+  gap: 18px;
+}
+
+.studio-archive__reviews {
+  grid-column: 1 / -1;
+  border: 1px solid var(--color-rule);
+  border-radius: var(--studio-radius);
+}
+
+.studio-archive__reviews {
+  display: grid;
+  grid-template-columns: minmax(220px, .8fr) minmax(0, 1.2fr);
+  gap: 34px;
+  align-items: center;
+  padding: clamp(24px, 3vw, 34px) clamp(26px, 3.4vw, 42px);
+}
+
+.studio-archive__reviews > div > p {
+  margin: 0 0 7px;
+  color: var(--color-ink);
+  font-family: var(--font-display);
+  font-size: 1.25rem;
+  font-weight: 620;
+}
+
+.studio-archive__reviews > div > span {
+  color: var(--color-ink-muted);
+  font-family: var(--font-prose);
+  font-size: .88rem;
+}
+
+.studio-archive__annual-links {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.studio-archive__annual-links a {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px clamp(14px, 2vw, 24px);
+  border-left: 1px solid var(--color-rule);
+  color: var(--color-ink);
+  font-family: var(--font-display);
+  font-size: clamp(1.35rem, 2vw, 1.85rem);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.studio-archive__annual-links a span {
+  color: var(--studio-accent);
+  font-family: var(--font-mono);
+  font-size: .8rem;
+}
+
+.studio-archive__annual-links a:hover {
+  color: var(--studio-accent);
+}
+
+.studio-archive__monthly {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: minmax(200px, .8fr) minmax(360px, 1.2fr) auto;
+  gap: 28px;
+  align-items: center;
+  margin-top: 6px;
+  padding-top: 26px;
+  border-top: 1px solid var(--color-rule);
+}
+
+.studio-archive__monthly > div > p {
+  margin: 0 0 5px;
+  color: var(--color-ink);
+  font-family: var(--font-display);
+  font-size: 1rem;
+  font-weight: 620;
+}
+
+.studio-archive__monthly > div > span {
+  color: var(--color-ink-muted);
+  font-family: var(--font-prose);
+  font-size: .78rem;
+}
+
+.studio-archive__monthly nav {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(44px, 1fr));
+  border-left: 1px solid var(--color-rule);
+}
+
+.studio-archive__monthly nav a {
+  display: grid;
+  gap: 3px;
+  place-items: center;
+  min-height: 52px;
+  border-right: 1px solid var(--color-rule);
+  color: var(--color-ink);
+  text-decoration: none;
+  transition: color 160ms ease, background 160ms ease;
+}
+
+.studio-archive__monthly nav a:hover {
+  color: var(--studio-accent);
+  background: color-mix(in srgb, var(--studio-accent) 5%, transparent);
+}
+
+.studio-archive__monthly nav b {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  font-weight: 620;
+  line-height: 1;
+}
+
+.studio-archive__monthly nav span {
+  color: var(--color-ink-muted);
+  font-family: var(--font-mono);
+  font-size: .52rem;
+  line-height: 1;
+}
+
+.studio-archive__monthly-all {
+  color: var(--studio-accent);
+  font-family: var(--font-meta);
+  font-size: .72rem;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.studio-archive__monthly-all:hover {
+  color: var(--color-ink);
 }
 
 .studio-workbench h2,
@@ -313,12 +547,7 @@ html[lang="zh"] .studio-manifesto h2 {
   padding-bottom: clamp(64px, 8vw, 92px);
 }
 
-.studio-manifesto {
-  padding-top: clamp(68px, 9vw, 104px);
-  padding-bottom: clamp(68px, 9vw, 104px);
-}
-
-.studio-manifesto,
+.studio-archive,
 .studio-workbench,
 .studio-products,
 .studio-road,
@@ -415,22 +644,44 @@ html[lang="zh"] .studio-manifesto h2 {
   }
 
   .studio-hero__viewport {
-    height: 320px;
+    height: 286px;
   }
 
   .studio-hero__visual {
-    right: 12px;
-    width: calc(100% - 24px);
+    right: 7px;
+    width: calc(100% - 14px);
+    border-radius: 20px;
+  }
+
+  .studio-hero__viewport::before {
+    inset: 20px 0 8px 24px;
+    border-radius: 22px;
   }
 
   .studio-hero__visual img {
-    height: 230px;
-    max-height: 230px;
-    aspect-ratio: 16 / 10;
+    height: 100%;
+    max-height: none;
+    aspect-ratio: auto;
+  }
+
+  .studio-hero__visual figcaption {
+    min-height: 92px;
+    padding: 38px 18px 16px;
   }
 
   .studio-hero__controls {
-    right: 12px;
+    right: 14px;
+    top: 12px;
+  }
+
+  .studio-hero__controls > span {
+    min-width: 44px;
+    margin-left: 6px;
+  }
+
+  .studio-hero__controls button {
+    width: 36px;
+    height: 36px;
   }
 
   .studio-signature {
@@ -449,31 +700,72 @@ html[lang="zh"] .studio-manifesto h2 {
     line-height: 1.65;
   }
 
-  .studio-manifesto h2,
-  html[lang="zh"] .studio-manifesto h2 {
-    font-size: clamp(2.05rem, 9.2vw, 2.65rem);
+  .studio-archive {
+    padding-top: 64px;
+    padding-bottom: 64px;
   }
 
-  .studio-manifesto__loop {
+  .studio-archive__intro {
     grid-template-columns: 1fr;
-    gap: 0;
-    margin-top: 34px;
+    gap: 20px;
   }
 
-  .studio-manifesto__loop > i {
-    display: none;
+  .studio-archive__intro h2,
+  html[lang="zh"] .studio-archive__intro h2 {
+    font-size: clamp(2rem, 9vw, 2.55rem);
   }
 
-  .studio-manifesto__loop button {
-    min-height: 58px;
-    padding: 11px 2px;
-    font-size: 1.55rem;
+  .studio-archive__intro > p {
+    max-width: 38ch;
   }
 
-  .studio-manifesto__insight,
-  .studio-manifesto div > p.studio-manifesto__insight {
-    margin-top: 24px;
-    font-size: 1.3rem;
+  .studio-archive__map {
+    grid-template-columns: 1fr;
+    margin-top: 38px;
+  }
+
+  .studio-archive__axis--practice,
+  .studio-archive__axis--thought,
+  .studio-archive__reviews {
+    grid-column: 1;
+  }
+
+  .studio-archive__axis {
+    min-height: 270px;
+  }
+
+  .studio-archive__reviews {
+    grid-template-columns: 1fr;
+    gap: 24px;
+  }
+
+  .studio-archive__annual-links {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .studio-archive__annual-links a {
+    padding: 8px 12px;
+    font-size: 1.2rem;
+  }
+
+  .studio-archive__annual-links a:first-child {
+    border-left: 0;
+  }
+
+  .studio-archive__monthly {
+    grid-template-columns: 1fr auto;
+    gap: 18px 12px;
+    padding-top: 22px;
+  }
+
+  .studio-archive__monthly nav {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .studio-archive__monthly-all {
+    grid-column: 2;
+    grid-row: 1;
   }
 
   .studio-workbench h2,
@@ -524,7 +816,7 @@ html[lang="zh"] .studio-manifesto h2 {
     padding-bottom: 58px;
   }
 
-  .studio-manifesto,
+  .studio-archive,
   .studio-workbench,
   .studio-products,
   .studio-road,
@@ -545,8 +837,7 @@ html[lang="zh"] .studio-manifesto h2 {
   .studio-workbench__grid .workspace-panel,
   .studio-products__track .studio-product,
   .studio-road__slide,
-  .studio-hero__controls button,
-  .studio-manifesto__loop button {
+  .studio-hero__controls button {
     transition: none;
     will-change: auto !important;
   }

--- a/assets/css/extended/about.css
+++ b/assets/css/extended/about.css
@@ -2261,7 +2261,7 @@ body.dark .bq-mountain::after {
 
 html[lang="zh"] .studio-hero h1 {
   max-width: 650px;
-  font-size: clamp(3rem, 4.7vw, 4.7rem);
+  font-size: clamp(3rem, 4vw, 4.5rem);
 }
 
 .studio-manifesto h2 {
@@ -2399,7 +2399,7 @@ html[lang="zh"] .studio-manifesto h2 {
 
 html[lang="zh"] .studio-hero h1 {
   max-width: 650px;
-  font-size: clamp(3rem, 4.7vw, 4.7rem);
+  font-size: clamp(3rem, 4vw, 4.5rem);
 }
 
 .studio-manifesto h2 {
@@ -3452,7 +3452,7 @@ html[lang="zh"] .about-name {
 }
 
 html[lang="zh"] .studio-hero h1 {
-  font-size: clamp(3rem, 5.4vw, 5.45rem);
+  font-size: clamp(3rem, 4vw, 4.5rem);
   line-height: 1.06;
   letter-spacing: -0.045em;
 }

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 baseURL: https://cubxxw.com
-title: 熊鑫伟 (cubxxw) 的博客 - AI Builder · Open Source Contributor · Digital Nomad
+title: 熊鑫伟 (cubxxw) 的博客 · 公开的实践与思想档案
 theme: PaperMod
 # Raise the per-template timeout above the 30s default: a cold build has to
 # generate every image variant (resize + WebP) on first render, which can
@@ -58,20 +58,23 @@ minify:
 params:
   env: production
   title: 熊鑫伟 (cubxxw) 的博客
-  description: AI Builder、开源贡献者、数字游民的技术博客：Kubernetes、Go、AI 开源项目与成长思考。
+  description: 熊鑫伟的公开实践与思想档案，记录 AI 工作流、真实项目、工程方法、系统思维，以及关于个人成长、哲学与人生的长期思考。
   keywords:
     - cubxxw
     - 熊鑫伟
-    - AI 创业
+    - AI 工作流
+    - AI 系统
     - 开源项目
     - Kubernetes
     - Go 语言
     - 云原生
     - 个人成长
-    - 数字游民
-    - 技术博客
+    - 系统思维
+    - 哲学
+    - 实践档案
   shortTitle: "cubxxw"
   author: 熊鑫伟 (Xinwei Xiong)
+  whatsappURL: "https://wa.me/8618672749565"
   # Public Telepace Headless SDK configuration. The campaign id is
   # intentionally empty in git: set HUGO_PARAMS_TELEPACEABOUTCAMPAIGNID in
   # Netlify after publishing the dedicated About feedback study.
@@ -306,7 +309,7 @@ languages:
     disabled: false
     languageCode: "en-us"
     languageDirection: "ltr"
-    title: "Xinwei Xiong (cubxxw) - AI, Open Source & Nomad Blog"
+    title: "Xinwei Xiong (cubxxw) · An Open Archive of Practice and Thought"
     contentDir: "content/en"
     languageName: English
     weight: 1
@@ -361,14 +364,14 @@ languages:
           pageRef: /about
           weight: 30
     params:
-      description: "Tech blog by Xinwei Xiong — AI Builder, open source contributor and digital nomad sharing Kubernetes, Go, AI projects and travel."
+      description: "Xinwei Xiong's open archive of AI workflows, real projects, engineering methods, systems thinking, personal growth, philosophy, and life."
       profileMode:
         # Enabled or not
         enabled: true
         title: Hi there 👋
         subtitle: |
-          My name is Xinwei (bear) Xiong 🤖 — AI Builder, Open Source Contributor, Digital Nomad.
-          Building AI products with Go & Kubernetes while exploring the world one adventure at a time ☀️.
+          I am Xinwei Xiong, a practitioner and writer.
+          This is my open archive of AI systems, engineering practice, real projects, growth, philosophy, and life.
         imageUrl: ../assets/cubxxw-image.jpg
         imageWidth: 120
         imageHeight: 120
@@ -395,7 +398,7 @@ languages:
     languageDirection: "ltr" # Left to Right for Chinese as well
     # Count CJK characters as words so WordCount / ReadingTime are correct
     hasCJKLanguage: true
-    title: "熊鑫伟（cubxxw）的简体中文博客 🇨🇳"
+    title: "熊鑫伟（cubxxw）· 公开的实践与思想档案"
     languageName: 简体中文
     contentDir: "content/zh"
     weight: 2
@@ -457,8 +460,8 @@ languages:
         enabled: true
         title: 你好 👋
         subtitle: |
-          我叫 Xinwei (bear) Xiong 🤖 — AI Builder、开源贡献者、数字游民。
-          我正在环游世界的路上，用代码和文字记录每一次冒险与思考 ☀️。
+          我是熊鑫伟，一名实践者与写作者。
+          这里是我的公开实践与思想档案，记录 AI 系统、工程实践、真实项目、个人成长、哲学与人生。
         imageUrl: ../assets/cubxxw-image.jpg
         imageWidth: 120
         imageHeight: 120

--- a/content/en/about.md
+++ b/content/en/about.md
@@ -2,8 +2,8 @@
 title: "About Me"
 menuTitle: "About"
 layout: "about"
-description: "Meet Xinwei Xiong (cubxxw), an independent product builder, open-source contributor, and traveler. Explore his daily workspace, AI products in progress, travel photography, and writing on growth and human judgment."
-summary: "Turning the road I travel into things people can use."
+description: "Meet Xinwei Xiong (cubxxw) and his open archive of practice and thought, covering AI workflows, real projects, engineering methods, personal growth, philosophy, and life."
+summary: "Turning lived practice into knowledge that compounds over time."
 ShowReadingTime: false
 ShowShareButtons: false
 ShowPostNavLinks: false
@@ -23,9 +23,9 @@ type: page
 author: ["Xinwei Xiong"]
 keywords: ["About", "Self", "Identity", "Personal Introduction", "About Me", "Reading Atlas", "Start Here"]
 tldr:
-  - "Xinwei Xiong (cubxxw) walks to observe the world, writes to understand himself, and builds products that turn understanding into something useful."
-  - "He keeps returning to one question: as AI learns more about us, how can a person preserve their experience, judgment, and path of growth?"
-  - "The page opens his daily workspace, products in progress, travel photography, and curated reading paths."
+  - "cubxxw.com is Xinwei Xiong's open archive for lived practice, judgment, and long-term thinking."
+  - "The writing grows from real projects and spans AI workflows, engineering methods, systems thinking, personal growth, philosophy, and life."
+  - "It does not chase short-term trends. Articles stay open and evolve with new practice and evidence."
 ---
 
 <!-- ── Coda · Reading atlas (#start-here 301 target).

--- a/content/zh/about.md
+++ b/content/zh/about.md
@@ -2,8 +2,8 @@
 title: "关于我"
 menuTitle: "关于"
 layout: "about"
-description: "认识熊鑫伟（cubxxw）：独立产品创造者、开源贡献者与旅居者。浏览他的日常工作区、正在构建的 AI 产品、真实旅行照片，以及关于写作、成长和人的判断的长期思考。"
-summary: "把走过的路，做成可以使用的东西。"
+description: "认识熊鑫伟（cubxxw），以及这份公开的实践与思想档案。这里沉淀 AI 工作流、真实项目、工程方法，以及关于个人成长、哲学与人生的长期思考。"
+summary: "把真实实践，沉淀成能穿越时间的知识。"
 ShowReadingTime: false
 ShowShareButtons: false
 ShowPostNavLinks: false
@@ -23,9 +23,9 @@ type: page
 author: ["Xinwei Xiong"]
 keywords: ["About", "Self", "Identity", "个人介绍", "关于我", "阅读地图", "Start Here"]
 tldr:
-  - "熊鑫伟（cubxxw）通过旅居观察世界，通过写作理解自己，再把理解做成产品。"
-  - "他持续关心一个问题：AI 越来越懂我们时，一个人怎样保存自己的经历、判断和成长轨迹。"
-  - "页面展示他的日常工作区、正在构建的产品、旅行照片与精选阅读路径。"
+  - "cubxxw.com 是熊鑫伟公开沉淀实践、判断与长期思考的个人知识档案。"
+  - "内容来自真实项目，覆盖 AI 工作流、工程方法、系统思维、个人成长、哲学与人生。"
+  - "这里不追逐短期热点，文章会随新的实践与证据持续修订，并全部公开。"
 ---
 
 <!-- ── 尾 · 阅读地图（/start-here 301 落点，保留锚点）。

--- a/layouts/page/about.html
+++ b/layouts/page/about.html
@@ -6,10 +6,17 @@
 {{- $telepaceWsURL := site.Params.telepaceWsBaseURL | default "wss://api.telepace.cubxxw.com" -}}
 {{- $telepaceCampaignID := site.Params.telepaceAboutCampaignID | default "" -}}
 {{- $telepaceConfigured := ne $telepaceCampaignID "" -}}
+{{- $languagePages := where site.RegularPages "Lang" .Language.Lang -}}
+{{- $archivePages := where $languagePages "Type" "posts" -}}
+{{- $practicePages := where $archivePages "Section" "in" (slice "ai-agent" "engineering") -}}
+{{- $projectPages := where $languagePages "Section" "projects" -}}
+{{- $thoughtPages := where $archivePages "Section" "growth" -}}
+{{- $monthlyPages := where $thoughtPages "File.BaseFileName" "like" `^[0-9]{4}-[0-9]{2}-thought-notes$` -}}
+{{- $practiceCount := add (len $practicePages) (len $projectPages) -}}
 {{- $heroSlides := slice
-  (dict "image" "/images/about/journey/10-taprohm.webp" "zhLabel" "在路上" "enLabel" "FIELD NOTES" "zh" "换一个地方，也换一种看问题的角度。" "en" "Change the place. Change the angle.")
-  (dict "image" "/images/about/journey/06-kumano.webp" "zhLabel" "持续行走" "enLabel" "KEEP MOVING" "zh" "走得更远，才能看见问题真正的形状。" "en" "Walk farther. See the problem clearly.")
-  (dict "image" "/images/about/journey/09-vangvieng.webp" "zhLabel" "正在创造" "enLabel" "BUILD IN PUBLIC" "zh" "把沿途的观察，做成别人可以使用的产品。" "en" "Turn observations into products people can use.")
+  (dict "image" "/images/about/journey/10-taprohm.webp" "zhLabel" "深入现场" "enLabel" "GET CLOSE" "zh" "离真实问题更近，判断才有根。" "en" "Judgment needs contact with reality.")
+  (dict "image" "/images/about/journey/06-kumano.webp" "zhLabel" "持续实践" "enLabel" "KEEP TESTING" "zh" "让每个结论接受现实与时间的检验。" "en" "Let reality and time test every conclusion.")
+  (dict "image" "/images/about/journey/09-vangvieng.webp" "zhLabel" "公开沉淀" "enLabel" "MAKE IT OPEN" "zh" "把个人经验整理成他人可以复用的路径。" "en" "Turn personal experience into reusable paths.")
 -}}
 {{- $journey := slice
   (dict "image" "/images/about/journey/01-nantaihang.webp" "zh" "南太行，中国" "en" "South Taihang, China")
@@ -35,28 +42,28 @@
             alt="{{ if $isZH }}熊鑫伟的头像插画{{ else }}Illustrated portrait of Xinwei Xiong{{ end }}"
             loading="eager" decoding="async">
           <p>
-            <span>{{ if $isZH }}熊鑫伟 · 独立创造者{{ else }}Xinwei Xiong · Independent builder{{ end }}</span>
-            {{ if $isZH }}写代码，也写下生活{{ else }}Building software and recording a life{{ end }}
+            <span>{{ if $isZH }}熊鑫伟 · 实践者与写作者{{ else }}Xinwei Xiong · Practitioner and writer{{ end }}</span>
+            {{ if $isZH }}构建系统，也理解人{{ else }}Building systems and understanding people{{ end }}
           </p>
         </div>
 
         <h1>
           {{ if $isZH }}
-          把走过的路，<br>做成<span>可以使用的东西。</span>
+          把真实实践，<br>沉淀成<span>长期有用的知识。</span>
           {{ else }}
-          Turning the road I travel<br>into <span>things people can use.</span>
+          Turning lived practice<br>into <span>knowledge that stays useful.</span>
           {{ end }}
         </h1>
         <p class="studio-hero__lead">
           {{ if $isZH }}
-          我通过旅居观察世界，通过写作理解自己，再把真实问题做成产品。
+          我构建 AI 系统和真实产品，公开其中的工作流、工程方法与判断，也写个人成长、哲学与人生。
           {{ else }}
-          I travel to observe the world, write to understand myself, and turn real questions into products.
+          I build AI systems and real products, document the workflows and engineering judgment behind them, and write about growth, philosophy, and life.
           {{ end }}
         </p>
         <nav class="studio-hero__actions" aria-label="{{ if $isZH }}页面导航{{ else }}Page navigation{{ end }}">
-          <a href="#workbench">{{ if $isZH }}进入我的工作台{{ else }}Enter my workbench{{ end }}</a>
-          <a href="{{ "projects/" | relLangURL }}">{{ if $isZH }}查看全部产品{{ else }}View all products{{ end }}</a>
+          <a href="#blog-definition">{{ if $isZH }}理解这个博客{{ else }}Understand this blog{{ end }}</a>
+          <a href="{{ "articles/" | relLangURL }}">{{ if $isZH }}开始阅读{{ else }}Start reading{{ end }}</a>
         </nav>
       </div>
 
@@ -96,29 +103,69 @@
       </div>
     </header>
 
-    <section class="studio-manifesto" aria-labelledby="studio-manifesto-title">
-      <div class="studio-manifesto__content" data-manifesto>
-        <h2 id="studio-manifesto-title">
-          {{ if $isZH }}不经营标签。<br>建立一种生活。{{ else }}Not collecting labels.<br>Building a life.{{ end }}
+    <section class="studio-archive" id="blog-definition" aria-labelledby="studio-archive-title">
+      <header class="studio-archive__intro">
+        <h2 id="studio-archive-title">
+          {{ if $isZH }}从这里，看见我公开过的实践与思想。{{ else }}A map of everything I have made public.{{ end }}
         </h2>
-        <div class="studio-manifesto__loop" role="group"
-          aria-label="{{ if $isZH }}我的生活方法{{ else }}My way of living{{ end }}">
-          <button type="button" aria-pressed="true" data-manifesto-tab="0" data-step="01">
-            {{ if $isZH }}行走{{ else }}Move{{ end }}
-          </button>
-          <i aria-hidden="true">→</i>
-          <button type="button" aria-pressed="false" data-manifesto-tab="1" data-step="02">
-            {{ if $isZH }}写作{{ else }}Write{{ end }}
-          </button>
-          <i aria-hidden="true">→</i>
-          <button type="button" aria-pressed="false" data-manifesto-tab="2" data-step="03">
-            {{ if $isZH }}创造{{ else }}Build{{ end }}
-          </button>
-        </div>
-        <p class="studio-manifesto__insight" role="status" aria-live="polite" data-manifesto-insight
-          data-insights="{{ if $isZH }}走近现场，才有资格形成判断。|写下来，模糊的经验才会变成判断。|交到用户手里，判断才开始接受现实检验。{{ else }}Get close to reality before forming a judgment.|Writing turns blurred experience into judgment.|A judgment becomes real only when users can test it.{{ end }}">
-          {{ if $isZH }}走近现场，才有资格形成判断。{{ else }}Get close to reality before forming a judgment.{{ end }}
+        <p>
+          {{ if $isZH }}
+          项目、工作方法、成长记录和年度总结，都按主题与时间整理在这里。
+          {{ else }}
+          Projects, working methods, personal reflections, and annual reviews, organized by subject and time.
+          {{ end }}
         </p>
+      </header>
+
+      <div class="studio-archive__map">
+        <article class="studio-archive__axis studio-archive__axis--practice">
+          <p><span>{{ if $isZH }}实践与项目{{ else }}Practice and projects{{ end }}</span><b>{{ $practiceCount }}</b></p>
+          <h3>{{ if $isZH }}从真实问题出发，留下系统、代码与取舍。{{ else }}Systems, code, and tradeoffs that began with real problems.{{ end }}</h3>
+          <nav aria-label="{{ if $isZH }}实践主题{{ else }}Practice topics{{ end }}">
+            <a href="{{ "ai-agent/" | relLangURL }}">AI Agent</a>
+            <a href="{{ "engineering/" | relLangURL }}">{{ if $isZH }}工程方法{{ else }}Engineering{{ end }}</a>
+            <a href="{{ "projects/" | relLangURL }}">{{ if $isZH }}开源项目{{ else }}Open projects{{ end }}</a>
+          </nav>
+        </article>
+
+        <article class="studio-archive__axis studio-archive__axis--thought">
+          <p><span>{{ if $isZH }}思想与成长{{ else }}Thought and growth{{ end }}</span><b>{{ len $thoughtPages }}</b></p>
+          <h3>{{ if $isZH }}关于成长、关系、选择，以及怎样理解自己。{{ else }}Growth, relationships, choices, and ways of understanding oneself.{{ end }}</h3>
+          <a class="studio-archive__axis-link" href="{{ "growth/" | relLangURL }}">
+            {{ if $isZH }}阅读思想与成长{{ else }}Read thought and growth{{ end }} <span aria-hidden="true">→</span>
+          </a>
+        </article>
+
+        <section class="studio-archive__reviews" aria-labelledby="studio-archive-reviews">
+          <div>
+            <p id="studio-archive-reviews">{{ if $isZH }}年度总结{{ else }}Annual reviews{{ end }}</p>
+            <span>{{ if $isZH }}每一年，重新检查生活的方向。{{ else }}A yearly check on the direction of life.{{ end }}</span>
+          </div>
+          <nav class="studio-archive__annual-links" aria-label="{{ if $isZH }}年度总结列表{{ else }}Annual review list{{ end }}">
+            <a href="{{ "growth/posts/2025-annual-review/" | relLangURL }}">2025 <span>↗</span></a>
+            <a href="{{ "growth/posts/2024-annual-review/" | relLangURL }}">2024 <span>↗</span></a>
+            <a href="{{ "growth/posts/2023-annual-summary-reflections-and-aspirations/" | relLangURL }}">2023 <span>↗</span></a>
+          </nav>
+
+          <div class="studio-archive__monthly">
+            <div>
+              <p>{{ if $isZH }}最近月记{{ else }}Recent monthly notes{{ end }}</p>
+              <span>{{ if $isZH }}六个月，六个思考现场。{{ else }}Six months, six fields of thought.{{ end }}</span>
+            </div>
+            <nav aria-label="{{ if $isZH }}最近六篇月度总结{{ else }}Six latest monthly notes{{ end }}">
+              {{- range first 6 $monthlyPages.ByDate.Reverse }}
+              <a href="{{ .RelPermalink }}" title="{{ .Title }}" aria-label="{{ .Title }}">
+                <b>{{ .Date.Format "01" }}</b>
+                <span>{{ .Date.Format "2006" }}</span>
+              </a>
+              {{- end }}
+            </nav>
+            <a class="studio-archive__monthly-all" href="{{ "tags/monthly-notes/" | relLangURL }}">
+              {{ if $isZH }}全部月记{{ else }}All monthly notes{{ end }} <span aria-hidden="true">→</span>
+            </a>
+          </div>
+        </section>
+
       </div>
     </section>
 
@@ -126,8 +173,8 @@
       role="region" aria-roledescription="carousel" data-card-carousel>
       <header>
         <div>
-          <p>{{ if $isZH }}我的日常工作区{{ else }}MY DAILY WORKSPACE{{ end }}</p>
-          <h2 id="studio-workbench-title">{{ if $isZH }}每天，我在这三个空间之间切换。{{ else }}Every day, I move between these three spaces.{{ end }}</h2>
+          <p>{{ if $isZH }}长期写作主线{{ else }}LONG-TERM THREADS{{ end }}</p>
+          <h2 id="studio-workbench-title">{{ if $isZH }}三个彼此相连的世界。{{ else }}Three connected worlds.{{ end }}</h2>
         </div>
         <div class="studio-deck-controls">
           <span role="status" aria-live="polite" aria-atomic="true"><b data-card-current>01</b> / 03</span>
@@ -144,9 +191,9 @@
             alt="{{ if $isZH }}Telepace 产品界面{{ else }}Telepace product interface{{ end }}" loading="lazy" decoding="async"
             draggable="false">
           <div>
-            <span>{{ if $isZH }}构建{{ else }}Build{{ end }}</span>
-            <h3>{{ if $isZH }}把模糊的问题做成可验证的产品{{ else }}Turn unclear problems into testable products{{ end }}</h3>
-            <p>{{ if $isZH }}产品、代码、用户访谈，以及一次次更小的实验。{{ else }}Product, code, user interviews, and smaller experiments each time.{{ end }}</p>
+            <span>{{ if $isZH }}AI 与项目{{ else }}AI and projects{{ end }}</span>
+            <h3>{{ if $isZH }}把深度工作流做成真实、可验证的系统{{ else }}Turn deep workflows into real, testable systems{{ end }}</h3>
+            <p>{{ if $isZH }}公开项目过程、AI 协作方式、代码与关键取舍。{{ else }}Openly documenting project process, AI collaboration, code, and key tradeoffs.{{ end }}</p>
           </div>
         </article>
 
@@ -157,8 +204,8 @@
             alt="{{ if $isZH }}cubxxw 博客文章阅读界面{{ else }}Article reading interface on cubxxw.com{{ end }}" loading="lazy" decoding="async"
             draggable="false">
           <div>
-            <span>{{ if $isZH }}写作{{ else }}Write{{ end }}</span>
-            <h3>{{ if $isZH }}把经验整理成别人可以继续走的路{{ else }}Turn experience into a path others can continue{{ end }}</h3>
+            <span>{{ if $isZH }}工程与方法{{ else }}Engineering and methods{{ end }}</span>
+            <h3>{{ if $isZH }}把隐性的判断整理成可复用的方法{{ else }}Turn tacit judgment into reusable methods{{ end }}</h3>
           </div>
         </article>
 
@@ -167,8 +214,8 @@
             alt="{{ if $isZH }}熊野古道上的森林与行者{{ else }}Forest and walker on the Kumano Kodo{{ end }}" loading="lazy" decoding="async"
             draggable="false">
           <div>
-            <span>{{ if $isZH }}移动{{ else }}Move{{ end }}</span>
-            <h3>{{ if $isZH }}换一个地方，也换一种看问题的角度{{ else }}Change the place, then change the angle{{ end }}</h3>
+            <span>{{ if $isZH }}人与世界{{ else }}People and the world{{ end }}</span>
+            <h3>{{ if $isZH }}在成长、哲学与人生中理解系统背后的人{{ else }}Understand the person behind the systems through growth, philosophy, and life{{ end }}</h3>
           </div>
         </article>
       </div>
@@ -407,6 +454,7 @@
       </div>
       <nav aria-label="{{ if $isZH }}联系方式{{ else }}Contact links{{ end }}">
         <a href="mailto:3293172751nss@gmail.com">{{ if $isZH }}聊一个问题{{ else }}Talk through a problem{{ end }} ↗</a>
+        <a href="{{ site.Params.whatsappURL | safeURL }}" target="_blank" rel="noopener">{{ if $isZH }}WhatsApp 联系我{{ else }}WhatsApp{{ end }} ↗</a>
         <a href="https://github.com/cubxxw" target="_blank" rel="noopener">GitHub ↗</a>
         <a href="https://x.com/cubxxw" target="_blank" rel="noopener">X ↗</a>
         <a href="{{ "about/quest/" | relLangURL }}">{{ if $isZH }}Bear Quest{{ else }}Bear Quest{{ end }} →</a>
@@ -573,11 +621,11 @@
             renderHero(heroIndex + 1);
             heroHasStarted = true;
             startHeroAutoplay(true);
-          }, 5200);
+          }, 3600);
           return;
         }
         heroHasStarted = true;
-        heroTimer = window.setInterval(function () { renderHero(heroIndex + 1); }, 2800);
+        heroTimer = window.setInterval(function () { renderHero(heroIndex + 1); }, 2400);
       }
 
       heroCarousel.querySelector('[data-hero-prev]').addEventListener('click', function () {
@@ -638,7 +686,7 @@
     }
 
     var revealSections = Array.prototype.slice.call(root.querySelectorAll(
-      '.studio-manifesto, .studio-workbench, .studio-products, .studio-road, .studio-interview, .studio-coda'
+      '.studio-archive, .studio-workbench, .studio-products, .studio-road, .studio-interview, .studio-coda'
     ));
     revealSections.forEach(function (section) { section.setAttribute('data-about-section', ''); });
 
@@ -654,37 +702,6 @@
       revealSections.forEach(function (section) { sectionObserver.observe(section); });
     } else {
       revealSections.forEach(function (section) { section.classList.add('is-visible'); });
-    }
-
-    var manifesto = root.querySelector('[data-manifesto]');
-    if (manifesto) {
-      var manifestoTabs = Array.prototype.slice.call(manifesto.querySelectorAll('[data-manifesto-tab]'));
-      var manifestoInsight = manifesto.querySelector('[data-manifesto-insight]');
-      var manifestoInsights = manifestoInsight.dataset.insights.split('|');
-
-      function selectManifesto(nextIndex) {
-        manifestoTabs.forEach(function (tab, tabIndex) {
-          tab.setAttribute('aria-pressed', tabIndex === nextIndex ? 'true' : 'false');
-        });
-        manifestoInsight.textContent = manifestoInsights[nextIndex];
-        if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-          manifestoInsight.animate([
-            { opacity: .2, transform: 'translate3d(0, 6px, 0)' },
-            { opacity: 1, transform: 'translate3d(0, 0, 0)' }
-          ], { duration: 220, easing: 'cubic-bezier(.2, .76, .2, 1)' });
-        }
-      }
-
-      manifestoTabs.forEach(function (tab, tabIndex) {
-        tab.addEventListener('click', function () { selectManifesto(tabIndex); });
-        tab.addEventListener('keydown', function (event) {
-          if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
-          event.preventDefault();
-          var nextIndex = (tabIndex + (event.key === 'ArrowRight' ? 1 : -1) + manifestoTabs.length) % manifestoTabs.length;
-          manifestoTabs[nextIndex].focus();
-          selectManifesto(nextIndex);
-        });
-      });
     }
 
   })();

--- a/layouts/partials/index_profile.html
+++ b/layouts/partials/index_profile.html
@@ -1,8 +1,8 @@
 <div class="profile profile-home">
     {{- with site.Params.profileMode }}
-    {{- $heroLine := cond (eq site.Language.Lang "zh") "在这里阅读我的 AI 技术、成长思考与旅行见闻。" "Read my writing on AI technology, personal growth, and travel adventures." -}}
+    {{- $heroLine := cond (eq site.Language.Lang "zh") "一份关于 AI 系统、工程实践、真实项目与个人成长的公开档案。" "An open archive of AI systems, engineering practice, real projects, and personal growth." -}}
     {{- $statusText := cond (eq site.Language.Lang "zh") "状态：在线探索中" "STATUS: ONLINE & EXPLORING" -}}
-    {{- $roleText := cond (eq site.Language.Lang "zh") "AI 创业者 / 开源贡献者 / 数字游民" "AI Entrepreneur / Open Source Contributor / Digital Nomad" -}}
+    {{- $roleText := cond (eq site.Language.Lang "zh") "实践者 / 写作者 / 开源贡献者" "Practitioner / Writer / Open Source Contributor" -}}
     {{- $startHereText := cond (eq site.Language.Lang "zh") "从哪里开始" "Start Here" -}}
     {{- $aboutMeText := cond (eq site.Language.Lang "zh") "我是谁" "Who I Am" -}}
     {{- $latestPostsText := cond (eq site.Language.Lang "zh") "最近写了什么" "Latest Posts" -}}
@@ -32,7 +32,7 @@
                         <span>{{ $statusText }}</span>
                     </a>
                     <div class="profile_quick_links">
-                        <button class="profile_quick_link" type="button" onclick="triggerQuickAsk(this)" data-question="{{ if eq site.Language.Lang "zh" }}你是谁？介绍一下你自己，附上关于页面链接{{ else }}Who are you? Introduce yourself with a link to your about page{{ end }}" data-page="{{ "/about/" | absLangURL }}">
+                        <button class="profile_quick_link" type="button" onclick="triggerQuickAsk(this)" data-question="{{ if eq site.Language.Lang "zh" }}你是谁？介绍一下你自己，附上关于页面链接{{ else }}Who are you? Introduce yourself with a link to your about page{{ end }}" data-page="{{ "/about/" | relLangURL }}">
                             <span class="profile_quick_link__icon">👤</span>
                             <span>{{ $aboutMeText }}</span>
                         </button>
@@ -197,7 +197,7 @@
                     <span class="profile_panel__icon profile_panel__icon--travel">🌍</span>
                     <h3>{{ $travelLabel }}</h3>
                 </div>
-                <p>{{ if eq site.Language.Lang "zh" }}数字游民生活、9 国 35+ 城市旅行见闻与文化探索{{ else }}Digital nomad life across 9 countries, 35+ cities and cultural exploration{{ end }}</p>
+                <p>{{ if eq site.Language.Lang "zh" }}9 国 35+ 城市的旅行现场、徒步记录与文化观察{{ else }}Field notes, long walks, and cultural observations across 9 countries and 35+ cities{{ end }}</p>
                 <a href="{{ "travel/" | relLangURL }}" class="profile_view_all">{{ $viewAllText }}</a>
             </article>
 
@@ -242,7 +242,7 @@
                 <div class="profile_panel__topline">
                     <div>
                         <h2>Growth & Life</h2>
-                        <p>{{ if eq site.Language.Lang "zh" }}成长复盘与数字游民见闻{{ else }}Personal Growth & Nomad Life{{ end }}</p>
+                        <p>{{ if eq site.Language.Lang "zh" }}个人成长、认知方法与人生观察{{ else }}Personal growth, mental models, and reflections on life{{ end }}</p>
                     </div>
                 </div>
                 {{- $growthPages := where (where site.RegularPages "Section" "growth") "Lang" site.Language.Lang -}}

--- a/themes/PaperMod/layouts/partials/footer.html
+++ b/themes/PaperMod/layouts/partials/footer.html
@@ -45,14 +45,14 @@
                 <span class="title-icon">🔗</span> Quick Links
             </h3>
             <ul class="footer-links">
-                <li><a href="{{ "/about" | absLangURL }}">👤 About Me</a></li>
-                <li><a href="{{ "/articles" | absLangURL }}">📄 All Posts</a></li>
-                <li><a href="{{ "/ai-agent" | absLangURL }}">🤖 AI Agent</a></li>
-                <li><a href="{{ "/engineering" | absLangURL }}">⚙️ Engineering</a></li>
-                <li><a href="{{ "/growth" | absLangURL }}">🌱 Growth & Life</a></li>
-                <li><a href="{{ "/travel" | absLangURL }}">🌍 Travel</a></li>
-                <li><a href="{{ "/archives" | absLangURL }}">📚 Archives</a></li>
-                <li><a href="{{ "/tags" | absLangURL }}">🏷️ Tags</a></li>
+                <li><a href="{{ "/about/" | relLangURL }}">👤 About Me</a></li>
+                <li><a href="{{ "/articles/" | relLangURL }}">📄 All Posts</a></li>
+                <li><a href="{{ "/ai-agent/" | relLangURL }}">🤖 AI Agent</a></li>
+                <li><a href="{{ "/engineering/" | relLangURL }}">⚙️ Engineering</a></li>
+                <li><a href="{{ "/growth/" | relLangURL }}">🌱 Growth & Life</a></li>
+                <li><a href="{{ "/travel/" | relLangURL }}">🌍 Travel</a></li>
+                <li><a href="{{ "/archives/" | relLangURL }}">📚 Archives</a></li>
+                <li><a href="{{ "/tags/" | relLangURL }}">🏷️ Tags</a></li>
             </ul>
         </div>
 


### PR DESCRIPTION
## What changed

- Reframed the blog and About metadata around an open archive of practice and thought.
- Replaced the abstract manifesto with direct practice, thought, annual review, and lightweight monthly-note entry points.
- Redesigned the hero carousel as a single media window with restrained controls and responsive dark/mobile styling.
- Added WhatsApp contact support without exposing the phone number in visible copy.
- Switched affected internal navigation helpers to language-relative URLs.

## Why

The previous About experience relied on decorative interaction and stacked-card effects that did not help visitors understand what was worth reading. This revision makes the page useful at a glance while preserving the site's editorial character.

## Validation

- `make envbuild`
- Desktop and mobile visual checks
- Light and dark theme checks
- Verified About, annual review, monthly-note, archive, and language-relative links


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a responsive studio archive covering practice, thought, annual reviews, and monthly notes.
  * Added archive navigation, content counts, updated workspace cards, and WhatsApp contact access.
  * Refreshed the hero carousel with layered visuals, captions, controls, and improved responsive behavior.

* **Content Updates**
  * Updated English and Chinese About-page messaging, profile descriptions, titles, and keywords.
  * Revised site links and navigation to better support language-specific pages.

* **Improvements**
  * Refined typography, mobile layouts, transitions, and reduced-motion behavior across the About experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->