### PR TITLE
docs: 重写博客首页 README

### DIFF
--- a/.github/workflows/blog-post-workflow.yml
+++ b/.github/workflows/blog-post-workflow.yml
@@ -1,4 +1,4 @@
-name: Update README with latest blog posts
+name: 更新 README 最新文章
 
 on:
   schedule:
@@ -7,45 +7,25 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: write
+
 jobs:
   update-readme:
-    name: Update README (${{ matrix.lang }})
+    name: 从中文 RSS 更新最近文章
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - lang: EN
-            tag: My-Blog-EN
-            feed: "https://cubxxw.com/index.xml"
-          - lang: ZH
-            tag: My-Blog-ZH
-            feed: "https://cubxxw.com/zh/index.xml"
 
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Pull in ${{ matrix.lang }} posts
+      - name: 更新最近 8 篇中文文章
         uses: gautamkrishnar/blog-post-workflow@v1
         with:
-          comment_tag_name: ${{ matrix.tag }}
-          feed_list: ${{ matrix.feed }}
+          comment_tag_name: BLOG-POST-LIST
+          feed_list: "https://cubxxw.com/zh/index.xml"
           gh_token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          max_post_count: 100
-          commit_message: "🔥docs(main): update with latest blog feed from ${{ matrix.lang }}"
+          max_post_count: 8
+          commit_message: "docs: update latest Chinese blog posts"
           committer_username: "kubbot"
           disable_html_encoding: true
-
-      - name: Auto green commit
-        run: |
-          git config --local user.email "3293172751ysy@gmail.com"
-          git config --local user.name "kubbot"
-          git remote set-url origin https://${{ secrets.BOT_GITHUB_TOKEN }}@github.com/${{ github.repository }}
-          git pull --rebase
-          if git diff --cached --quiet && git diff --quiet; then
-            echo "No changes to commit, skipping."
-            exit 0
-          fi
-          git commit -a -s -m "🌟 You never lose, either you win or you learn! 💪"
-          git push

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-<h3 align="center" style="border-bottom: none">
-    <a href="https://cubxxw.com">
-      ⭐️  Welcome to my blog · cubxxw.com ⭐️ <br>
-    </a>
-</h3>
+<h1 align="center">写给 AI 时代的长期主义者</h1>
 
 <p align="center">
-  <b>熊鑫伟 (Xinwei Xiong / cubxxw)</b> —— AI Builder · 开源贡献者 · 数字游民<br>
-  <sub>在技术与人性之间搭建桥梁：AI Agent 工程、云原生、开源实践，以及一场走过 9 国 35+ 城的人生实验。</sub><br>
-  <sub><i>Building bridges between technology and humanity — AI agent engineering, cloud-native, open source, and a life experiment across 9 countries.</i></sub>
+  <b>这里不收藏知识。这里公开一个人如何把 AI 变成能力，把经历变成判断，把写作变成长期复利。</b>
+</p>
+
+<p align="center">
+  <a href="https://cubxxw.com/zh/"><strong>进入博客</strong></a>
+  &nbsp;·&nbsp;
+  <a href="#从这里开始">开始阅读</a>
+  &nbsp;·&nbsp;
+  <a href="https://cubxxw.com/zh/index.xml">订阅 RSS</a>
 </p>
 
 <!-- 👋 交个朋友 · Let's connect — 双平台扫码 / copyable ID, mirrors the on-site contact cards -->
@@ -33,232 +35,59 @@
   <br><br>
 </div>
 
-## Introduction
+## 这不是一个知识仓库
 
-> **这是一个 AI-native 的开源博客**，把「写作 + AI + 开源工程」揉在一起做长期实验。内容围绕四条主线免费开放：**AI Agent 工程**、**云原生 / Go 工程**、**成长与认知**、**旅行与数字游民**。所有文章、源码与实践笔记都可自由取用 —— 若对你有帮助，欢迎 Star、订阅或加我交流。
+知识正在变得无限、即时，并且越来越便宜。再多整理一份概念、转述一次共识，价值都很有限。
+
+真正稀缺的，是知识经过一个具体的人、一段真实经历和一次实际工作之后，留下的东西：做过什么，为什么这样做，哪里失败过，判断因此发生了怎样的变化。
+
+> AI 可以重写一段文字，却无法替我经历一次失败、做出一个选择，或为一个长期判断付出代价。
 >
-> **An AI-native open-source blog** — a long-running experiment blending writing, AI, and open-source engineering. Everything (posts, source, notes) is free to use across four threads: AI agent engineering, cloud-native/Go, growth & cognition, and travel & the nomad life. If it helps you, a Star or subscribe means a lot.
+> 这个仓库存下的，正是这些不可代写的部分。
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/10e9c8fc-0201-4d41-9240-5c35f10ee952/deploy-status)](https://app.netlify.com/sites/cubxxw/deploys)
+[cubxxw.com](https://cubxxw.com/zh/) 是我的公开写作现场。这里没有“每天学一个新概念”的任务，也不追逐看起来正确的答案。文章只沉淀三类东西：亲自验证过的实践、可以复用的工作流，以及经得起回看的思考。
 
-> [!TIP]
-> This is my third generation blog. The first two generations were dynamic blogs with unstable servers in the background. Fortunately, this blog is now more stable and will be continuously maintained.
+## 三条持续写下去的线
 
-> [!NOTE]
-> + [关于我](https://cubxxw.com/zh/about/)
-> + [一些碎片的思考笔记](https://cubxxw.com/zh/growth/)
-> + [跟着我看我环游世界旅居的笔记](https://www.polarsteps.com/cubxxw)
+**01 / 把 AI 变成一套真正能工作的系统**
 
+不止讨论模型和提示词，而是研究 Agent、上下文、记忆、评测、安全边界与自动化，怎样进入真实生产流程。这里保留架构选择，也保留失败现场。
 
-### 🔍 项目导航
+**02 / 把信息变成一个人的能力**
 
-- [LLM 相关项目](/tags/llm/)
-- [向量数据库](/tags/向量数据库/)
-- [AI 框架](/tags/ai框架/)
-- [AI 工具链](/tags/ai工具链/)
+信息不是知识，收藏也不是拥有。我持续拆解自己的知识管理、第二大脑、内容创作与个人工作流，关心的是它们如何穿过“信息—记录—知识—创作”，最后抵达行动。
 
-## Content Architecture (v3.0.0)
+**03 / 在机器越来越强的时候，继续成为一个具体的人**
 
-This blog uses a **4-section architecture** aligned with the author's identity as **AI Builder, Open Source Contributor, and Digital Nomad**.
+技术之外，我写选择、关系、身份、风险、城市与远行。不是为了给人生总结规律，而是留下足够诚实的现场证据：我在哪里，我经历了什么，我如何被它改变。
 
-| Section | Description | Content Coverage |
-|----------|-------------|------------------|
-| **AI Agent** (`/ai-agent/`) | Agent engineering, context engineering, LLM applications | Agent architecture, harness design, context/memory/RAG, GEO |
-| **Engineering** (`/engineering/`) | Kubernetes cloud-native, Go engineering, DevOps | K8s internals, Go tooling, CI/CD, open-source practice |
-| **Projects** | AI open source project deep-dives and product builds | LangChain, GPT-Researcher, Jina analysis, independent developer products |
-| **Growth** | Personal growth, annual reviews, mindset, efficiency methods | Annual reviews, monthly thoughts, GTD, Flow State, career development |
-| **Travel** | Travel experiences and digital nomad lifestyle | Travel itineraries, digital nomad life, cultural exploration, adventures |
+技术文章会尽量给出可复现的路径，思考文章会交代推理过程，个人文章会保留现场。它们共同回答同一个问题：
 
-For detailed category documentation, see [`content/CATEGORIES.md`](content/CATEGORIES.md).
+> 当越来越多的能力可以外包给 AI，什么仍然必须由自己完成？
 
----
+## 从这里开始
 
-## Tagging Standards
+如果你第一次来到这里，这几篇文章最接近这个仓库的内核：
 
-For comprehensive governance rules on category vs tag decisions, see [`docs/TAG_GOVERNANCE.md`](docs/TAG_GOVERNANCE.md).
+- [一个人带一队 Agent，把 120 多篇文章的博客重新组装了一遍](https://cubxxw.com/zh/ai-agent/posts/ai-native-blog-rebuild/) — 一次真实的大规模 Agent 协作现场，而不是自动化想象。
+- [AI 知识工作流：从信息、记录、知识到创作](https://cubxxw.com/zh/ai-agent/posts/info-to-creation-the-framework/) — 我如何划分个人知识系统里四种完全不同的东西。
+- [AI 工作流质量门禁：把软件工程的纪律搬进个人系统](https://cubxxw.com/zh/ai-agent/posts/engineering-discipline-ai-workflow/) — 让 AI 产出从“看起来不错”走向可验证、可恢复、可持续。
+- [Agent Engineering 全景地图：98.4% 只是 Harness 的叙事锚点](https://cubxxw.com/zh/ai-agent/posts/agent-engineering-the-98-percent-harness/) — 模型之外，真正决定 Agent 上限的工程系统。
+- [AI 解决问题以后，问题会搬到哪里](https://cubxxw.com/zh/growth/posts/2026-07-26-bottlenecks-after-ai/) — 当生产不再稀缺，判断、分发与责任如何成为新瓶颈。
+- [当生成变得无限，真实经历开始升值](https://cubxxw.com/zh/growth/posts/2026-07-31-reality-becomes-scarce-after-ai/) — 为什么 AI 越擅长生成，“亲自活过”反而越有价值。
 
-### Core Principles
+按主题继续阅读：
 
-- **Categories (1 per post)**: Broad content buckets for navigation - choose from 4 core categories
-- **Tags (5-8 per post)**: Specific topics and technologies - flexible and detailed
-- **Tag Naming**: Use Title Case, avoid duplicates (e.g., use `Go` not `golang` or `Golang`)
-- **Language Consistency**: Use English tags for both CN/EN blogs for unified tagging
+[AI Agent](https://cubxxw.com/zh/ai-agent/) ·
+[工程实践](https://cubxxw.com/zh/engineering/) ·
+[成长与思考](https://cubxxw.com/zh/growth/) ·
+[全部文章](https://cubxxw.com/zh/articles/)
 
-### Tag Groups (9 Categories)
-|-------|------|
-| **Programming Languages** | Go, Python, JavaScript, TypeScript, Rust, Java |
-| **Cloud Native** | Kubernetes, Docker, Cloud Native, Helm, Istio, Containerd |
-| **AI/ML** | AI, Machine Learning, Deep Learning, LLM, NLP, Computer Vision |
-| **Technology** | DevOps, Automation, Testing, Performance, Security, Monitoring, CI/CD |
-| **Architecture** | Microservices, System Design, Distributed Systems, Event-Driven |
-| **Tools** | Git, GitHub, VS Code, Linux, Vim, Docker Desktop |
-| **Open Source** | Open Source, Community, Contribution, Maintenance |
-| **Life** | Blog, Travel, Personal Growth, Self-Discovery, Reading, Reflection |
-| **Culture** | Remote Work, Team Collaboration, Management, Leadership |
+## 最近在写
 
-### Usage Guidelines
+下面只保留最近发布的 8 篇中文文章，由 GitHub Actions 从博客 RSS 自动更新。这个列表会变化，仓库也会继续生长。
 
-- **Categories (1 per post)**: Broad content buckets for navigation - choose from 4 core categories
-- **Tags (5-8 per post)**: Specific topics and technologies - flexible and detailed
-- **Tag Naming**: Use Title Case, avoid duplicates (e.g., use `Go` not `golang` or `Golang`)
-- **Language Consistency**: Use English tags for both CN/EN blogs for unified tagging
-
-For detailed tagging standards, see [`TAGS.md`](TAGS.md).
-
----
-
-## Subscribe
-
-The articles published on the blog are independent, which is what I have seen and learned since participating in open source projects, and I hope this model can be successful and copied. [👀 My blog](https://cubxxw.com/) has a lot of good content and is worth a read. If you want to subscribe to the SSR 🔍 [here](https://cubxxw.com/articles/index.xml)
-
-[<img align="left" alt="shenxianpeng | ZhiHu" width="22px" src="https://www.svgrepo.com/show/305628/zhihu.svg" />][zhihu] 
-
-[zhihu]: https://www.zhihu.com/people/3293172751
-
-<a href="https://www.zhihu.com/people/3293172751" target="_blank"><img src="https://img.shields.io/badge/%E7%9F%A5%E4%B9%8E-%E9%93%BE%E5%AD%A6%E8%80%85%E7%A4%BE%E5%8C%BA-blue?logo=zhihu&style=flat-square"></a>
-<a href="assets/wechat.jpg" target="_blank"><img src="https://img.shields.io/badge/%E5%BE%AE%E4%BF%A1-smile-brightgreen?logo=wechat&style=flat-square"></a>
-
-
-**Default English blog subscription：**
-
-+ English: [https://cubxxw.com/articles/index.xml](https://cubxxw.com/articles/index.xml)
-
-
-**Default Chinese blog subscription：**
-
-+ Chinese: [https://cubxxw.com/zh/articles/index.xml](https://cubxxw.com/zh/articles/index.xml)
-
-
-**Default Spain blog subscription：**
-
-+ Spain: [https://cubxxw.com/es/articles/index.xml](https://cubxxw.com/es/articles/index.xml)
-
-
-**Default French blog subscription：**
-
-+ French: [https://cubxxw.com/fr/articles/index.xml](https://cubxxw.com/fr/articles/index.xml)
-
-
-**Speed up subscription links for inaccessible networks：**
-
-```bash
-https://rss.starerror.com/${RSS_ADDRESS}
-```
-
-
-### Featured blog subscriptions in English (default)
-
-Here you'll find the latest and most interesting blog posts in English from Xinwei Xiong(cubxxw).
-
-<!-- My-Blog-EN:START -->
-- [The Scoreboard You Choose Will Eventually Choose You: How Incentives Reshape an Organization](https://cubxxw.com/growth/posts/2026-07-31-incentives-colonize-founders/)
-- [The Opposite of Freedom Isn’t Constraint—It’s the Defaults That Live Your Day for You](https://cubxxw.com/growth/posts/2026-07-31-freedom-and-defaults/)
-- [When Generation Becomes Infinite, Authentic Experiences Begin to Command Value](https://cubxxw.com/growth/posts/2026-07-31-reality-becomes-scarce-after-ai/)
-- [Risk Preference Isn't About Enjoying Danger: What Truly Enables Taking a Bet](https://cubxxw.com/growth/posts/2026-07-31-risk-is-not-danger/)
-- [The Cost of Observation: Why the More You Understand, the Harder It Is to Enter Life](https://cubxxw.com/growth/posts/2026-07-31-the-observer-cannot-enter-life/)
-- [Creators Don’t Lack Applause—They Lack an Accurate Witness](https://cubxxw.com/growth/posts/2026-07-31-creators-need-accurate-witnesses/)
-- [Forgetting Is Harder Than Remembering: Why a Living System Must Know When to Let Go](https://cubxxw.com/ai-agent/posts/2026-07-31-forgetting-is-an-ai-system-capability/)
-- [Records Are Not Mirrors, But Scissors: What Tool You Use Ultimately Shapes Who You Become](https://cubxxw.com/growth/posts/2026-07-31-recording-tools-shape-the-self/)
-- [Environment as the Hidden Author: Why Moving Cities Feels Like Becoming Someone Else](https://cubxxw.com/growth/posts/2026-07-31-environment-is-the-hidden-author/)
-- [When Distance No Longer Changes You: What Keeps Life Moving After Exploration Fails](https://cubxxw.com/growth/posts/2026-07-31-when-exploration-stops-changing-you/)
-- [Every Path Has a Price](https://cubxxw.com/growth/posts/2026-07-26-every-path-has-a-price/)
-- [After AI Solves a Problem, Where Does the Bottleneck Move?](https://cubxxw.com/growth/posts/2026-07-26-bottlenecks-after-ai/)
-- [The Fastest Numbers Are Often Furthest from the Outcome](https://cubxxw.com/growth/posts/2026-07-26-fast-feedback-slow-results/)
-- [Action Does Not Automatically Lead to Truth](https://cubxxw.com/growth/posts/2026-07-26-action-and-evidence/)
-- [The Escape Routes of Smart People: Applying Ability to the Wrong Problem](https://cubxxw.com/growth/posts/2026-07-26-competence-trap/)
-- [What Does Profit Actually Prove?](https://cubxxw.com/growth/posts/2026-07-26-profit-and-value/)
-- [What Should I Do Next? A Debate About Money, Action, and Ideals](https://cubxxw.com/growth/posts/2026-07-26-what-to-do-next/)
-- [Bear Quest — Play My Story](https://cubxxw.com/about/quest/)
-- [Open Design 0.16.1: A Design Harness for Coding Agents](https://cubxxw.com/ai-agent/posts/open-design/)
-- [Claude Code Playbook: 10 Configurations for Reliable Agent Workflows](https://cubxxw.com/ai-agent/posts/claude-code-boris-121-tips-playbook/)
-- [Loop Engineering for Solo Builders: Verifiers, State, and Safe Automation](https://cubxxw.com/ai-agent/posts/prompt-loop-engineering-practice/)
-- [You Think You're the Player — But "Player" Is Also a Role: Rereading the Samādhi of Play](https://cubxxw.com/growth/posts/2026-07-20-the-player-is-also-a-role/)
-- [A Solo Creator's AI Video Editing Pipeline That Actually Works](https://cubxxw.com/ai-agent/posts/solo-creator-video-pipeline/)
-- [When Anyone Can Build the Thing, "He Built It" Becomes the Signal](https://cubxxw.com/ai-agent/posts/super-individual-stack-reputation/)
-- [Your Product Can Be Copied Overnight. Your Readers Can't.](https://cubxxw.com/ai-agent/posts/super-individual-stack-distribution/)
-- [AI Writes Requirements for Free, and That's the Most Dangerous Part](https://cubxxw.com/ai-agent/posts/super-individual-stack-judgment/)
-- [I Ran Ten Agents Overnight, Woke Up to Ten PRs, and Then I Got Stuck](https://cubxxw.com/ai-agent/posts/super-individual-stack-production/)
-- [Your Gear Is Arming Your Competitors Too](https://cubxxw.com/ai-agent/posts/super-individual-stack-four-layers/)
-- [Designing devbox-doctor: A Safer Mac Toolchain Audit](https://cubxxw.com/ai-agent/posts/devbox-doctor-design/)
-- [Agent Skill Design: What a Dangerous SKILL.md Taught Me](https://cubxxw.com/ai-agent/posts/designing-valuable-agent-skills/)
-- [Field Notes: I Built My Knowledge Layer into an Arsenal](https://cubxxw.com/ai-agent/posts/info-to-creation-arsenal/)
-- [How AI Agents Rebuilt My 120-Post Blog From Scratch](https://cubxxw.com/ai-agent/posts/ai-native-blog-rebuild/)
-- [Where AI Agents Still Have a Blue Ocean](https://cubxxw.com/ai-agent/posts/ai-agent-red-ocean-blue-ocean-2026/)
-- [How to Build Real Trust in Unattended AI Agents That Act](https://cubxxw.com/ai-agent/posts/trusting-unattended-ai-agent/)
-- [The Super Individual's Intelligence System: Building a Personal Pipeline From Information to Action With Agents and MCP](https://cubxxw.com/ai-agent/posts/super-individual-intelligence-system/)
-- [Agent Fleet Economics in 2026: Testing Low-Cost APIs and Open-Weight Options](https://cubxxw.com/ai-agent/posts/open-model-cost-collapse-agent-fleet/)
-- [When the AI Agent Starts Prompting You, What Has Actually Changed](https://cubxxw.com/ai-agent/posts/proactive-agent-it-prompts-you/)
-- [AI News Pipelines: Automation Limits and Human Judgment](https://cubxxw.com/ai-agent/posts/ai-auto-news-pipeline-limits/)
-- [What Remains When You Take It All Apart: On No-Self, Suffering, and "You Could Say It Either Way"](https://cubxxw.com/growth/posts/2026-07-14-what-remains-when-taken-apart/)
-- [From Chatbot to Agent to Skill: Turning Judgment into a System](https://cubxxw.com/ai-agent/posts/from-chatbot-to-agent-to-skill/)
-- [Give AI Tasks, Not Just Direction: Define Done First](https://cubxxw.com/ai-agent/posts/give-ai-tasks-not-directions/)
-- [Friction Is Growth: When AI Removes All Resistance for You, Deliberately Keep Some](https://cubxxw.com/growth/posts/friction-is-growth/)
-- [AI Workflow Quality Gates: A Practical Engineering Guide](https://cubxxw.com/ai-agent/posts/engineering-discipline-ai-workflow/)
-- [Build an AI Second Brain with Claude and Obsidian](https://cubxxw.com/ai-agent/posts/ai-second-brain-build/)
-- [Layer Four · Creation: Recombining Knowledge Into Something Others Are Willing to Receive](https://cubxxw.com/ai-agent/posts/info-to-creation-creation/)
-- [Layer Three · Knowledge: Your Knowledge Base Is Not a Bookmark Folder, It Is Your Capability Sediment Zone](https://cubxxw.com/ai-agent/posts/info-to-creation-knowledge/)
-- [Layer Two · Records: The Highest-Conversion Semi-Finished Product Between Information and Knowledge](https://cubxxw.com/ai-agent/posts/info-to-creation-record/)
-- [Layer One · Information: What to Show AI, What to Skim Yourself, and Pure Noise](https://cubxxw.com/ai-agent/posts/info-to-creation-information/)
-- [Information, Records, Knowledge, Creation: In the AI Era, I Split My Notes Into Four Different Things](https://cubxxw.com/ai-agent/posts/info-to-creation-the-framework/)
-- [GEO Measurement & Tools: How to Know If AI Actually Cites You (with a DIY Monitor)](https://cubxxw.com/ai-agent/posts/geo-measurement-and-tools/)
-- [GEO Blog Rebuild Case Study: Running the Five-Layer Model on Real Data](https://cubxxw.com/ai-agent/posts/geo-blog-rebuild-case-study/)
-- [GEO Trust & Endorsement: Why Reddit and Wikipedia Make Up Half of AI Citations](https://cubxxw.com/ai-agent/posts/geo-trust-and-endorsement/)
-- [GEO Structured Tactics: Writing "Worth Citing" Into Every Paragraph (Answer-First, Schema, llms.txt)](https://cubxxw.com/ai-agent/posts/geo-structured-content-tactics/)
-- [GEO Mechanics: How AI Retrieves, Re-ranks, and Cites You](https://cubxxw.com/ai-agent/posts/geo-how-ai-retrieves-and-cites/)
-- [GEO: The Complete Guide to Generative Engine Optimization (When Search Stops Giving Links and Starts Giving Answers)](https://cubxxw.com/ai-agent/posts/geo-generative-engine-optimization-guide/)
-- [2026 June Thought Notes: The Pushing-Away Comes Before the Reason for Pushing Away](https://cubxxw.com/growth/posts/2026-06-thought-notes/)
-- [Inside open-lovable: Search, Text Protocols, and Sandboxes](https://cubxxw.com/ai-agent/posts/dissecting-open-lovable/)
-- [Ignite and Settle (Part 3): Anxious Attachment — Why We Keep Seeking Reassurance in Love](https://cubxxw.com/growth/posts/2026-06-28-ignite-and-settle-3-anxious/)
-- [Ignite and Settle (Part 2): Avoidant Attachment — Why We Want to Run When Someone Gets Close](https://cubxxw.com/growth/posts/2026-06-28-ignite-and-settle-2-avoidant/)
-- [Ignite and Settle (Part 1): The Quality and Time of Companionship — and Why We Turn Away Just as We Come Close](https://cubxxw.com/growth/posts/2026-06-28-ignite-and-settle-1-quality-and-time/)
-- [The Super-Individual Stack: AI-Native Product Directions and Solo Builder Ops in 2026](https://cubxxw.com/growth/posts/super-individual-ai-product-and-solo-builder-stack/)
-- [Relay Agent Architecture in 2026: A Local Implementation Audit](https://cubxxw.com/ai-agent/posts/relay-agent-architecture-design/)
-- [Seen Clearly, Loved Deeply: Five Lenses on Love, and the Buddhist Synthesis](https://cubxxw.com/growth/posts/love-seen-clearly-loved-deeply/)
-- [Context Engineering: The New Foundation for AI Agents](https://cubxxw.com/ai-agent/posts/context-engineering-the-new-foundation/)
-- [Agent Engineering Harness: The Eight Pillars Behind the 98.4%](https://cubxxw.com/ai-agent/posts/agent-engineering-the-98-percent-harness/)
-- [2026 May Thought Notes: On the Edge, I Recognize Myself Through Action](https://cubxxw.com/growth/posts/2026-05-thought-notes/)
-- [April 2026 Thought Notes](https://cubxxw.com/growth/posts/2026-04-thought-notes/)
-- [Agent Identity: From Locke to OpenClaw](https://cubxxw.com/ai-agent/posts/agent-identity-from-locke-to-openclaw/)
-- [Maintaining Self-Worth in the Age of AI](https://cubxxw.com/growth/posts/weight-of-self-in-ai-age/)
-- [March 2026 Thought Notes](https://cubxxw.com/growth/posts/2026-03-thought-notes/)
-- [Lhasa: Slow and Heavy](https://cubxxw.com/growth/posts/2026-03-27-lhasa-slow-and-heavy/)
-- [Wandering & Growing: 2025-2026 Annual Review](https://cubxxw.com/growth/posts/2025-annual-review/)
-- [AI and Self-Identity: Who Am I in the AI Age](https://cubxxw.com/growth/posts/ai-and-self-identity/)
-- [February 2026 Thought Notes](https://cubxxw.com/growth/posts/2026-02-thought-notes/)
-- [January 2026 Thought Notes](https://cubxxw.com/growth/posts/2026-01-thought-notes/)
-- [December 2025 Thought Notes](https://cubxxw.com/growth/posts/2025-12-thought-notes/)
-- [Japan Travel Notes — Learning to Be with Time Through Wood, Fire, and Gaps](https://cubxxw.com/growth/posts/japan-travel-2025/)
-- [2025 November Thought Notes](https://cubxxw.com/growth/posts/2025-11-thought-notes/)
-- [October 2025 Thought Notes](https://cubxxw.com/growth/posts/2025-10-thought-notes/)
-- [September 2025 Thought Notes](https://cubxxw.com/growth/posts/2025-09-thought-notes/)
-- [2025 August Thought Notes](https://cubxxw.com/growth/posts/2025-08-thought-notes/)
-- [2025 July Thought Notes](https://cubxxw.com/growth/posts/2025-07-thought-notes/)
-- [2025 June Thought Notes](https://cubxxw.com/growth/posts/2025-06-thought-notes/)
-- [How I Learned to Observe My Own Thinking: A Four-Month Metacognitive Shift](https://cubxxw.com/growth/posts/metacognitive-transformation-review/)
-- [2025 May Thought Notes](https://cubxxw.com/growth/posts/2025-05-thought-notes/)
-- [Mem0 OSS v3 in Practice: Memory Architecture, Retrieval, and Trade-offs](https://cubxxw.com/projects/mem0/)
-- [Microsoft UFO³ Explained: From Windows Desktop AgentOS to a Multi-Device Agent Galaxy](https://cubxxw.com/projects/UFO/)
-- [2025 April Thought Notes](https://cubxxw.com/growth/posts/2025-04-thought-notes/)
-- [LLM Recommendation Systems: Retrieval, Ranking, RAG, and Evaluation](https://cubxxw.com/ai-agent/posts/ai-recommend/)
-- [Gemini Notebook (Formerly NotebookLM): A Source-Grounded Research Workflow](https://cubxxw.com/projects/notebooklm/)
-- [Test-Driven Development for AI and LLM Applications: A Practical 2026 Guide](https://cubxxw.com/projects/tdd/)
-- [Microsoft MarkItDown 0.1.6: A Practical Document-to-Markdown Guide](https://cubxxw.com/projects/markitdown/)
-- [LangGraph Architecture in 2026: StateGraph, Persistence, and Recovery](https://cubxxw.com/projects/langgraph/)
-- [LangChain 1.x in Production: Choosing Models, Agents, and LangGraph](https://cubxxw.com/projects/langchain/)
-- [AI Gateway Guide: LiteLLM, Kong, APISIX, Cloudflare, or Portkey?](https://cubxxw.com/ai-agent/posts/ai-gateway/)
-- [Independent Developer Roadmap: From Problem Validation to a Maintainable MVP](https://cubxxw.com/ai-agent/posts/independent-developer/)
-- [GPT Researcher Guide: Python, Docker, MCP, Costs & Limits](https://cubxxw.com/ai-agent/posts/gpt-researcher/)
-- [Jina AI in 2026: Embeddings, Reranking, Reader, and Jina Serve](https://cubxxw.com/ai-agent/posts/jina/)
-- [2025 March Thought Notes](https://cubxxw.com/growth/posts/2025-03-thought-notes/)
-- [2024 Annual Review](https://cubxxw.com/growth/posts/2024-annual-review/)
-<!-- My-Blog-EN:END -->
-
-
-### 中文博客精选订阅
-
-这里你可以看到Xinwei Xiong(cubxxw)的最新和最有趣的中文博客文章。
-
-<!-- My-Blog-ZH:START -->
+<!-- BLOG-POST-LIST:START -->
 - [你选择的计分板，最后会选择你：激励怎样改写一个组织](https://cubxxw.com/zh/growth/posts/2026-07-31-incentives-colonize-founders/)
 - [自由的反面不是约束，是默认值替你活完一天](https://cubxxw.com/zh/growth/posts/2026-07-31-freedom-and-defaults/)
 - [第二大脑保存的，是一个人的决策函数](https://cubxxw.com/zh/growth/posts/2026-07-31-second-brain-as-survival-strategy/)
@@ -267,174 +96,46 @@ Here you'll find the latest and most interesting blog posts in English from Xinw
 - [观察者的代价：看得越明白，为什么反而越难进入生活](https://cubxxw.com/zh/growth/posts/2026-07-31-the-observer-cannot-enter-life/)
 - [创造者缺的不是掌声，是一个准确的见证者](https://cubxxw.com/zh/growth/posts/2026-07-31-creators-need-accurate-witnesses/)
 - [AI 时代，遗忘比记忆更难：一个活系统为什么必须会放下](https://cubxxw.com/zh/ai-agent/posts/2026-07-31-forgetting-is-an-ai-system-capability/)
-- [记录不是镜子，是剪刀：你用什么工具，最后就会成为什么样的人](https://cubxxw.com/zh/growth/posts/2026-07-31-recording-tools-shape-the-self/)
-- [环境是隐藏的作者：为什么换一座城，像换了一个自己](https://cubxxw.com/zh/growth/posts/2026-07-31-environment-is-the-hidden-author/)
-- [当远方不再改变你：探索失效以后，人生靠什么继续向前](https://cubxxw.com/zh/growth/posts/2026-07-31-when-exploration-stops-changing-you/)
-- [每条路都要收费](https://cubxxw.com/zh/growth/posts/2026-07-26-every-path-has-a-price/)
-- [AI 解决问题以后，问题会搬到哪里](https://cubxxw.com/zh/growth/posts/2026-07-26-bottlenecks-after-ai/)
-- [越快看到的数字，往往离结果越远](https://cubxxw.com/zh/growth/posts/2026-07-26-fast-feedback-slow-results/)
-- [行动不会自动带来真相](https://cubxxw.com/zh/growth/posts/2026-07-26-action-and-evidence/)
-- [聪明人的逃跑方式：把能力用在不该解决的问题上](https://cubxxw.com/zh/growth/posts/2026-07-26-competence-trap/)
-- [利润到底证明了什么](https://cubxxw.com/zh/growth/posts/2026-07-26-profit-and-value/)
-- [下一步做什么：一场关于赚钱、行动与理想的争论](https://cubxxw.com/zh/growth/posts/2026-07-26-what-to-do-next/)
-- [小熊人生游戏 — Play My Story](https://cubxxw.com/zh/about/quest/)
-- [Open Design 0.16.1：给 Coding Agent 一张可复用的设计工作台](https://cubxxw.com/zh/ai-agent/posts/open-design/)
-- [Claude Code 实战手册：从验证闭环到并行代理的 10 个配置](https://cubxxw.com/zh/ai-agent/posts/claude-code-boris-121-tips-playbook/)
-- [独立开发者的 Loop Engineering：验证器、状态与安全自动化](https://cubxxw.com/zh/ai-agent/posts/prompt-loop-engineering-practice/)
-- [你以为你是玩家，可「玩家」也是一个角色：重读游戏三昧](https://cubxxw.com/zh/growth/posts/2026-07-20-the-player-is-also-a-role/)
-- [独立创作者的 AI 视频剪辑流水线：拍摄、粗剪与多平台发布](https://cubxxw.com/zh/ai-agent/posts/solo-creator-video-pipeline/)
-- [当东西人人做得出来，「这是他做的」就成了信号](https://cubxxw.com/zh/ai-agent/posts/super-individual-stack-reputation/)
-- [你的产品一夜就能被抄走，你的读者不能](https://cubxxw.com/zh/ai-agent/posts/super-individual-stack-distribution/)
-- [AI 提需求不要钱，这才是最危险的地方](https://cubxxw.com/zh/ai-agent/posts/super-individual-stack-judgment/)
-- [夜里跑十个 agent，早上收十个 PR，然后我卡住了](https://cubxxw.com/zh/ai-agent/posts/super-individual-stack-production/)
-- [你的装备，同时也在武装你的对手](https://cubxxw.com/zh/ai-agent/posts/super-individual-stack-four-layers/)
-- [你的 Mac 上有几套工具在打架？我设计了一个开发机体检 Skill](https://cubxxw.com/zh/ai-agent/posts/devbox-doctor-design/)
-- [Agent Skill 与 SKILL.md 设计：我拆了一个敢删文件的插件](https://cubxxw.com/zh/ai-agent/posts/designing-valuable-agent-skills/)
-- [番外·实践：我把「知识层」建成了一座兵工厂](https://cubxxw.com/zh/ai-agent/posts/info-to-creation-arsenal/)
-- [一个人带一队 Agent，把 120 多篇文章的博客重新组装了一遍](https://cubxxw.com/zh/ai-agent/posts/ai-native-blog-rebuild/)
-- [2026 AI Agent 红海与蓝海：垂直工作流、支付协议与责任护城河](https://cubxxw.com/zh/ai-agent/posts/ai-agent-red-ocean-blue-ocean-2026/)
-- [如何建立对无人值守 AI Agent 的真实信任](https://cubxxw.com/zh/ai-agent/posts/trusting-unattended-ai-agent/)
-- [超级个体的情报系统：用 Agent 和 MCP 搭一条从信息采集到行动的个人流水线](https://cubxxw.com/zh/ai-agent/posts/super-individual-intelligence-system/)
-- [一个人养得起多大的 Agent 舰队：2026 年低价 API 与开放权重模型的成本账](https://cubxxw.com/zh/ai-agent/posts/open-model-cost-collapse-agent-fleet/)
-- [当 AI Agent 开始反过来提示你，真正改变了什么](https://cubxxw.com/zh/ai-agent/posts/proactive-agent-it-prompts-you/)
-- [让 AI 自动帮你追全网资讯，最后会卡在哪里](https://cubxxw.com/zh/ai-agent/posts/ai-auto-news-pipeline-limits/)
-- [拆到最后，剩下的才是你：一场关于无我、痛苦与"怎么说都可以"的追问](https://cubxxw.com/zh/growth/posts/2026-07-14-what-remains-when-taken-apart/)
-- [从 Chatbot 到 Agent 到 Skill：AI 落地传统行业的真正分水岭](https://cubxxw.com/zh/ai-agent/posts/from-chatbot-to-agent-to-skill/)
-- [给 AI 任务，不只给方向：用完成态把协作落到结果](https://cubxxw.com/zh/ai-agent/posts/give-ai-tasks-not-directions/)
-- [摩擦即成长：当 AI 替你消除一切阻力，请主动留下一些](https://cubxxw.com/zh/growth/posts/friction-is-growth/)
-- [AI 工作流质量门禁：把软件工程的纪律搬进个人系统](https://cubxxw.com/zh/ai-agent/posts/engineering-discipline-ai-workflow/)
-- [AI 第二大脑实操：Obsidian、Agent 与微信入口](https://cubxxw.com/zh/ai-agent/posts/ai-second-brain-build/)
-- [第四层·创作：把知识重组成别人愿意接收的东西](https://cubxxw.com/zh/ai-agent/posts/info-to-creation-creation/)
-- [第三层·知识：知识库不是收藏夹，是你的能力沉淀区](https://cubxxw.com/zh/ai-agent/posts/info-to-creation-knowledge/)
-- [第二层·记录：信息和知识之间，那个转化率最高的半成品](https://cubxxw.com/zh/ai-agent/posts/info-to-creation-record/)
-- [第一层·信息：给 AI 看的，给自己扫的，和纯粹的噪音](https://cubxxw.com/zh/ai-agent/posts/info-to-creation-information/)
-- [信息、记录、知识、创作：AI 时代，我把笔记拆成了四种东西](https://cubxxw.com/zh/ai-agent/posts/info-to-creation-the-framework/)
-- [GEO 度量与工具：怎么知道 AI 到底有没有引用你（附 DIY 监测）](https://cubxxw.com/zh/ai-agent/posts/geo-measurement-and-tools/)
-- [GEO 本博客改造复盘：用真实数据把五层模型跑一遍](https://cubxxw.com/zh/ai-agent/posts/geo-blog-rebuild-case-study/)
-- [GEO 信任与背书：为什么 Reddit 和 Wikipedia 占了 AI 引用的一大半](https://cubxxw.com/zh/ai-agent/posts/geo-trust-and-endorsement/)
-- [GEO 结构化实战：把"值得被引用"写进每一段（Answer-First、Schema、llms.txt）](https://cubxxw.com/zh/ai-agent/posts/geo-structured-content-tactics/)
-- [GEO 原理篇：AI 是怎么把你"检索 → 重排 → 引用"的](https://cubxxw.com/zh/ai-agent/posts/geo-how-ai-retrieves-and-cites/)
-- [GEO 生成式引擎优化完全指南：当搜索从"给链接"变成"给答案"](https://cubxxw.com/zh/ai-agent/posts/geo-generative-engine-optimization-guide/)
-- [2026年6月思考笔记：推开的动作，先于推开的理由](https://cubxxw.com/zh/growth/posts/2026-06-thought-notes/)
-- [open-lovable 源码拆解：Agentic Search、文本协议与双沙箱](https://cubxxw.com/zh/ai-agent/posts/dissecting-open-lovable/)
-- [点火与沉底（下）：焦虑型依恋——为什么爱里我们总在确认](https://cubxxw.com/zh/growth/posts/2026-06-28-ignite-and-settle-3-anxious/)
-- [点火与沉底（中）：回避型依恋——为什么靠近时我们想逃](https://cubxxw.com/zh/growth/posts/2026-06-28-ignite-and-settle-2-avoidant/)
-- [点火与沉底（上）：陪伴的质量与时间，和我们为什么总在快要靠近时转身](https://cubxxw.com/zh/growth/posts/2026-06-28-ignite-and-settle-1-quality-and-time/)
-- [超级个体的栈：2026 年 AI 原生 Solo Builder 的产品方向与运营全图](https://cubxxw.com/zh/growth/posts/super-individual-ai-product-and-solo-builder-stack/)
-- [Relay Agent 架构审计：从设计承诺到本地实现](https://cubxxw.com/zh/ai-agent/posts/relay-agent-architecture-design/)
-- [看穿之后，依然深爱：五副透镜下的爱，与佛学的统摄](https://cubxxw.com/zh/growth/posts/love-seen-clearly-loved-deeply/)
-- [Context 不是 Prompt：上下文工程如何成为 AI Agent 的新地基](https://cubxxw.com/zh/ai-agent/posts/context-engineering-the-new-foundation/)
-- [Agent Engineering 全景地图：98.4% 只是 Harness 的叙事锚点](https://cubxxw.com/zh/ai-agent/posts/agent-engineering-the-98-percent-harness/)
-- [2026年5月思考笔记：在边缘上，用行动认出自己](https://cubxxw.com/zh/growth/posts/2026-05-thought-notes/)
-- [2026年4月思考笔记](https://cubxxw.com/zh/growth/posts/2026-04-thought-notes/)
-- [Agent 的自我：从洛克到 OpenClaw](https://cubxxw.com/zh/ai-agent/posts/agent-identity-from-locke-to-openclaw/)
-- [在不被需要的时代，如何维持自我的重量](https://cubxxw.com/zh/growth/posts/weight-of-self-in-ai-age/)
-- [2026年3月思考笔记](https://cubxxw.com/zh/growth/posts/2026-03-thought-notes/)
-- [拉萨——一座城市的慢与重](https://cubxxw.com/zh/growth/posts/2026-03-27-lhasa-slow-and-heavy/)
-- [我在游荡，但我没有迷路 — 2025-2026 年度总结](https://cubxxw.com/zh/growth/posts/2025-annual-review/)
-- [AI 越来越聪明，我却越来越不知道自己是谁](https://cubxxw.com/zh/growth/posts/ai-and-self-identity/)
-- [2026年2月思考笔记](https://cubxxw.com/zh/growth/posts/2026-02-thought-notes/)
-- [2026年1月思考笔记](https://cubxxw.com/zh/growth/posts/2026-01-thought-notes/)
-- [2025年12月思考笔记](https://cubxxw.com/zh/growth/posts/2025-12-thought-notes/)
-- [日本旅居笔记 - 用木头、火与缺口和时间共处](https://cubxxw.com/zh/growth/posts/japan-travel-2025/)
-- [2025年11月思考笔记](https://cubxxw.com/zh/growth/posts/2025-11-thought-notes/)
-- [2025年10月思考笔记](https://cubxxw.com/zh/growth/posts/2025-10-thought-notes/)
-- [2025年9月思考笔记](https://cubxxw.com/zh/growth/posts/2025-09-thought-notes/)
-- [2025年8月思考笔记](https://cubxxw.com/zh/growth/posts/2025-08-thought-notes/)
-- [2025年7月思考笔记](https://cubxxw.com/zh/growth/posts/2025-07-thought-notes/)
-- [2025年6月思考笔记](https://cubxxw.com/zh/growth/posts/2025-06-thought-notes/)
-- [我如何学会观察自己的思考：四个月的元认知转变复盘](https://cubxxw.com/zh/growth/posts/metacognitive-transformation-review/)
-- [2025年5月思考笔记](https://cubxxw.com/zh/growth/posts/2025-05-thought-notes/)
-- [Mem0 OSS v3 实践：记忆架构、混合检索与生产取舍](https://cubxxw.com/zh/projects/mem0/)
-- [UFO² 桌面 AgentOS：从 Windows 自动化到 UFO³ Galaxy](https://cubxxw.com/zh/ai-agent/posts/UFO/)
-- [Argo CD: Declarative GitOps for Kubernetes Continuous Delivery](https://cubxxw.com/zh/engineering/posts/argo-cd/)
-- [2025年4月思考笔记](https://cubxxw.com/zh/growth/posts/2025-04-thought-notes/)
-- [LLM 推荐系统工程指南：语义召回、排序、强化学习与评估](https://cubxxw.com/zh/ai-agent/posts/ai-recommend/)
-- [Google NotebookLM 的 RAG 深度调研思考](https://cubxxw.com/zh/projects/notebooklm/)
-- [AI 与大模型应用的测试驱动开发：从确定性测试到风险化评测](https://cubxxw.com/zh/projects/tdd/)
-- [MarkItDown 文档转 Markdown 实战：0.1.6 机制基线与 0.1.7 状态](https://cubxxw.com/zh/projects/markitdown/)
-- [2026 LangGraph 架构指南：StateGraph、持久化与故障恢复](https://cubxxw.com/zh/projects/langgraph/)
-- [LangChain 1.x 生产实践：模型、Agent 与 LangGraph 如何选](https://cubxxw.com/zh/projects/langchain/)
-- [AI Gateway 选型指南：LiteLLM、Kong、APISIX、Cloudflare 与 Portkey 怎么选](https://cubxxw.com/zh/ai-agent/posts/ai-gateway/)
-- [独立开发者技术栈指南：从问题验证到可维护 MVP](https://cubxxw.com/zh/ai-agent/posts/independent-developer/)
-- [GPT Researcher 源码审计：深度研究代理如何检索、写作与自托管](https://cubxxw.com/zh/ai-agent/posts/gpt-researcher/)
-- [Jina 2026：搜索底座模型、API 与 Jina Serve 实战指南](https://cubxxw.com/zh/ai-agent/posts/jina/)
-<!-- My-Blog-ZH:END -->
+<!-- BLOG-POST-LIST:END -->
 
+## 一套公开运行的内容系统
 
-### Español blog destacado suscripción
+这个仓库不只是文章的最终展示层，也公开了内容如何被生产、校验与分发：
 
-Aquí encontrarás las últimas y más interesantes entradas de blog en español de Xinwei Xiong(cubxxw).
-
-<!-- My-Blog-ES:START -->
-
-<!-- My-Blog-ES:END -->
-
-
-### Français blog fr vedette abonnement
-
-Ici, vous trouverez les derniers articles de blog les plus intéressants en français de Xinwei Xiong(cubxxw).
-
-<!-- My-Blog-FR:START -->
-
-<!-- My-Blog-FR:END -->
-
-
-## Content style
-
-We don't mandate any particular style for your page contents. However, if you'd like some guidance on how to write and format clear, concise technical documentation, we recommend the [Google Developer Documentation Style Guide](https://developers.google.com/style/), particularly the [Style Guide Highlights](https://developers.google.com/style/highlights).
-
-
-## Running the website locally
-
-Clone the minikube project fork with option `--recurse-submodules --depth 1` to download and update submodule dependencies.
-
-```bash
-❯ git clone --recurse-submodules --depth 1 https://github.com/cubxxw/blog.git  # replace path with your github fork of minikube 
-❯ cd blog
+```text
+现实问题 → 公开研究 → 亲自实践 → 结构化写作 → 双语发布 → 自动索引与分发 → 复盘
 ```
 
-## Use
+- 选题从明确的 [写作 Brief](_briefs/README.md) 开始，不让 AI 凭空决定“应该写什么”。
+- 文章经过一套公开的 [编辑工作流](docs/blog-editorial-workflow.md)，把研究、写作、SEO / GEO、封面和发布拆成可验证的阶段。
+- 最新内容通过 RSS 自动回到 README；站点索引、构建与发布也由自动化持续维护。
+- 所有内容与系统都在真实使用中迭代。你看到的不只是方法，还有方法运行之后留下的结果。
+
+这可能是这个仓库最值得复用的部分：不是某个工具的配置，而是一套让经验持续变成内容、让内容持续变成资产的机制。
+
+## 如果它对你有用
+
+如果你也在尝试用 AI 构建产品、重组个人工作流，或者想在高密度的信息里保住自己的判断，欢迎点亮右上角的 **Star**。
+
+Star 不是对一个“完成品”的收藏。它更像是为未来留一个入口：我会继续把新的实践、失败、系统和思考放到这里，你也可以随时回来，看看一个真实的人如何与 AI 一起工作、创作和生活。
+
+- 阅读：[cubxxw.com](https://cubxxw.com/zh/)
+- 订阅：[中文 RSS](https://cubxxw.com/zh/index.xml) / [英文 RSS](https://cubxxw.com/index.xml)
+- 认识我：[关于](https://cubxxw.com/zh/about/)
+
+<details>
+<summary><strong>在本地运行这个博客</strong></summary>
 
 ```bash
-❯ make run
+git clone --recurse-submodules https://github.com/cubxxw/blog.git
+cd blog
+make run
 ```
 
-## Create a new article
+本地构建使用 `make envbuild`。
 
-```bash
-❯ make new-post SECTION="engineering" POST_NAME="openim-offline-deployment-design"
-```
+</details>
 
-**Named by an environment variable:**
+---
 
-```bash
-❯ SECTION="growth" POST_NAME="weekly-notes" make new-post
-❯ export POST_NAME="my-hugo"
-❯ export SECTION="engineering"
-❯ make new-post
-❯ make new-ai-project PROJECT_NAME="llama"
-```
-
-## Common Issues
-
-```bash
-Start building sites …
-hugo v0.86.0+extended darwin/amd64 BuildDate=unknown
-Error: Error building site: "/minikube/site/content/en/docs/contrib/releasing/binaries.md:64:1": failed to extract shortcode: template for shortcode "alert" not found
-Built in 667 ms
-```
-
-This indicates the submodules are not updated. Please run the following command to fix.
-
-```bash
-❯ git submodule update --init --recursive
-```
-
-**📱 加入社群 · Join the Community 🛠️**
-<p>扫描页首二维码，添加微信 <code>cubxxwAI</code> 或关注小红书 <code>nsddd_top</code>，一起交流 AI、开源与远程工作，并受邀加入我们的社群。<br>Scan the QR codes at the top — add me on WeChat <code>cubxxwAI</code> or follow me on RedNote <code>nsddd_top</code> to talk AI, open source & remote work, and join the community.</p>
-
-
-## Reference
-
-Uer netlify to deploy the blog, and use the [hexo-theme-next](ttps://cubxxw.netlify.app) theme. 
+熊鑫伟（Xinwei Xiong / cubxxw）持续写作与维护。仓库采用 [CC0 1.0](LICENSE)：带走、修改、重组，或把它变成你自己的系统。


### PR DESCRIPTION
## 修改内容

- 将 README 从仓库说明书重写为面向 AI 时代读者的中文内容入口
- 移除标签治理、空语言区、失效说明、重复订阅入口和超长文章列表
- 保留页首微信与小红书两个扫码区块原样不动
- 用三条内容主线、精选阅读入口和公开内容系统呈现博客的长期价值
- 将自动文章区收敛为最近 8 篇中文文章，并简化 RSS 更新工作流

## 为什么

旧 README 同时承担个人介绍、内部维护文档、标签规范和完整文章索引，核心价值被大量低信息密度内容掩盖。本次重写直接回答博客是什么、写什么、为什么值得持续关注，并把 Star 转化建立在真实内容和持续更新机制上。

## 验证

- `git diff --check`
- GitHub Actions YAML 解析通过
- RSS 自动更新 action 输入已对照上游 action 定义验证
- 两个扫码区块与修改前 SHA-256 一致
- README 内全部 22 个外部链接返回 HTTP 200
- 精选文章 slug 与本地内容文件逐一核对