### PR TITLE
Clarify the homepage public-archive identity

### DIFF
--- a/assets/css/extended/homepage-daypage.css
+++ b/assets/css/extended/homepage-daypage.css
@@ -113,6 +113,7 @@ body.dark .hp-city-sep {
   background: var(--bg-warm);
   color: var(--fg-primary);
   font-family: var(--font-body);
+  font-size-adjust: 0.52;
   font-size: 16px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
@@ -257,51 +258,6 @@ body.dark .hp-topbar { background: rgba(28, 25, 22, 0.85); }
   padding: 72px 0 80px;
 }
 
-.hp-hero-meta-row {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin-bottom: 20px;
-}
-
-.hp-status-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  padding: 5px 12px;
-  background: var(--accent-soft);
-  border: 1px solid var(--accent-border);
-  border-radius: var(--radius-pill);
-  font-family: var(--font-mono);
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: 1.2px;
-  text-transform: uppercase;
-  color: var(--accent);
-}
-
-.hp-live-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #4ade80;
-  animation: hp-blink 2s ease-in-out infinite;
-  flex-shrink: 0;
-}
-
-@keyframes hp-blink {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.35; }
-}
-
-.hp-entry-label {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  letter-spacing: 1.2px;
-  text-transform: uppercase;
-  color: var(--fg-subtle);
-}
-
 .hp-hero h1 {
   font-family: var(--font-display);
   font-weight: 700;
@@ -312,7 +268,7 @@ body.dark .hp-topbar { background: rgba(28, 25, 22, 0.85); }
      with the clamp so the display name stays optically tight at every size. */
   letter-spacing: -0.02em;
   color: var(--fg-primary);
-  margin: 0 0 16px;
+  margin: 0;
 }
 
 .hp-hero-name-row {
@@ -349,33 +305,18 @@ body.dark .hp-topbar { background: rgba(28, 25, 22, 0.85); }
   50% { transform: translateY(-4px); }
 }
 
-.hp-hero-tag {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-bottom: 20px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 2px;
-  text-transform: uppercase;
-  color: var(--fg-muted);
-}
-
-.hp-hero-tag .hp-sep { color: var(--border-default); }
-
 .hp-hero-bio {
   font-family: var(--font-body);
   font-size: 17px;
   line-height: 1.65;
   color: var(--fg-muted);
-  max-width: 460px;
-  margin: 0;
+  max-width: 520px;
+  margin: 16px 0 0;
 }
 
 .hp-hero-bio strong { color: var(--fg-primary); font-weight: 600; }
 
-/* Poetic motto line — the human statement under the persona tagline */
+/* Editorial statement under the author's name. */
 .hp-hero-motto {
   font-family: var(--font-display);
   font-size: clamp(20px, 2.6vw, 30px);
@@ -383,17 +324,8 @@ body.dark .hp-topbar { background: rgba(28, 25, 22, 0.85); }
   line-height: 1.35;
   letter-spacing: 0.4px;
   color: var(--fg-primary);
-  margin: 16px 0 0;
-}
-
-/* English signature line */
-.hp-hero-public {
-  font-family: var(--font-mono);
-  font-size: 12px;
-  letter-spacing: 1px;
-  text-transform: uppercase;
-  color: var(--accent);
-  margin: 14px 0 0;
+  max-width: 620px;
+  margin: 28px 0 0;
 }
 
 /* About Me CTA — subtle inline link, not a heavy pill */
@@ -2349,7 +2281,12 @@ body.dark .hp-heatmap-year-tab.active { color: #1C1916; }
   .hp-page { padding: 0 20px; }
   .hp-topbar-inner { padding: 0 20px; gap: 16px; }
   .hp-nav { display: none; }
-  .hp-hero { grid-template-columns: 1fr; padding: 48px 0 56px; gap: 40px; }
+  .hp-hero {
+    grid-template-columns: 1fr;
+    min-height: 33.5rem;
+    padding: 48px 0 56px;
+    gap: 40px;
+  }
   .hp-posts-grid { grid-template-columns: 1fr; }
   /* Channel rail: the track scrolls horizontally; tabs grow to a
      comfortable touch height. */
@@ -2406,6 +2343,11 @@ body.dark .hp-heatmap-year-tab.active { color: #1C1916; }
      they wrapped 6 + 1 with an orphan icon on its own row. */
   .hp-hero-socials {
     gap: 6px;
+  }
+  .hp-hero-socials .hp-social-icon--buymeacoffee,
+  .hp-hero-socials .hp-social-icon--instagram,
+  .hp-hero-socials .hp-social-icon--facebook {
+    display: none;
   }
   .hp-social-icon {
     width: 42px;

--- a/data/homepage.yml
+++ b/data/homepage.yml
@@ -3,24 +3,12 @@ hero:
   nameLast: "Xiong"
   nameZh: "熊鑫伟"
   nickZh: "BEAR"
-  # Persona tagline — replaces the old "AI BUILDER / OPEN SOURCE / DIGITAL NOMAD"
-  tagline:
-    - "风险偏好者"
-    - "徒步"
-    - "创造者"
-  taglineEn:
-    - "RISK-TAKER"
-    - "HIKER"
-    - "BUILDER"
-  # Poetic motto line under the name
-  mottoZh: "脚踏泥地，也仰望星辰"
-  mottoEn: "Feet on the mud, eyes on the stars"
-  # English signature line
-  publicLine: "All is builder. Builder is public."
-  bioEn: "I build <strong>AI products</strong> and contribute to <strong>open source</strong> while wandering the world. Capturing raw signals from each day — code, thoughts, places — and compiling them into something durable."
-  bioZh: "构建 <strong>AI 产品</strong>，贡献<strong>开源代码</strong>，在世界的褶皱里慢慢走。每天捕捉原始信号——代码、念头、地方——让它们结晶成能留下来的东西。"
-  footerBioEn: "Xinwei Xiong — AI builder, open source contributor and digital nomad. Kubernetes, Go, AI agents & travel."
-  footerBioZh: "熊鑫伟 — AI 构建者、开源贡献者、数字游民。在中国与世界之间慢慢走的探索者。"
+  mottoZh: "把真实实践，沉淀成能穿越时间的知识。"
+  mottoEn: "Turning lived practice into knowledge that compounds over time."
+  bioEn: "I openly document <strong>AI workflows</strong>, real projects, and engineering judgment, alongside long-term writing on <strong>growth, philosophy, and life</strong>."
+  bioZh: "这里公开我的 <strong>AI 工作流</strong>、真实项目与工程方法，也记录关于<strong>个人成长、哲学与人生</strong>的长期思考。"
+  footerBioEn: "Xinwei Xiong. An open archive of AI systems, engineering practice, projects, growth, and philosophy."
+  footerBioZh: "熊鑫伟的公开实践与思想档案。记录 AI 系统、工程方法、真实项目、个人成长与哲学。"
   siteVersion: "v3.0"
 
 # Section tiles under "Writing" — rendered by homepage-daypage.html .hp-cat-row

--- a/data/start_here.json
+++ b/data/start_here.json
@@ -154,7 +154,7 @@
     },
     "colophon": {
       "label": "关于本站",
-      "entity": "cubxxw.com 是熊鑫伟（Xinwei Xiong，网名 cubxxw）的个人博客。他生于 2001 年，是一名 AI 创业者、开源贡献者与数字游民，活跃于 OpenIM、OpenKF、Sealos 等开源项目。博客写作围绕四条主线：AI Agent（LLM 应用、智能体工程、GEO，以及 MarkItDown、LangGraph、NotebookLM 等开源项目的源码深读）、工程与开源（Kubernetes、Go、DevOps 与开源实践）、成长与思考（年度复盘、元认知、心流），以及旅行与观察（9 个国家、35+ 城市、400+ 公里徒步）。",
+      "entity": "cubxxw.com 是熊鑫伟（Xinwei Xiong，网名 cubxxw）的公开实践与思想档案。内容来自真实项目、工程选择与生活经验，长期记录 AI 工作流、智能体工程、开源实践、系统思维、个人成长、哲学与人生。作者参与过 OpenIM、OpenKF、Sealos 等开源项目，也持续把实践中的方法、失败与判断完整公开。",
       "facts": [
         {
           "k": "作者",
@@ -162,11 +162,11 @@
         },
         {
           "k": "身份",
-          "v": "AI 创业者 · 开源贡献者 · 数字游民"
+          "v": "实践者 · 写作者 · 开源贡献者"
         },
         {
           "k": "主题",
-          "v": "AI Agent / 工程与开源 / 成长与思考 / 旅行与观察"
+          "v": "AI 系统 / 工程方法 / 真实项目 / 成长与哲学"
         },
         {
           "k": "足迹",
@@ -348,7 +348,7 @@
     },
     "colophon": {
       "label": "About this site",
-      "entity": "cubxxw.com is the personal blog of Xinwei Xiong (known online as cubxxw). Born in 2001, he is an AI founder, open-source contributor, and digital nomad, active in projects such as OpenIM, OpenKF, and Sealos. The blog follows four threads: AI agents (LLM applications, agent engineering, GEO, and source-level deep dives into MarkItDown, LangGraph, NotebookLM, and more), engineering & open source (Kubernetes, Go, DevOps), growth & thinking (annual reviews, metacognition, flow), and travel & observation (9 countries, 35+ cities, 400+ km on foot).",
+      "entity": "cubxxw.com is Xinwei Xiong's open archive of practice and thought. Its writing grows from real projects, engineering choices, and lived experience, covering AI workflows, agent engineering, open-source practice, systems thinking, personal growth, philosophy, and life. Xinwei has contributed to projects including OpenIM, OpenKF, and Sealos, and openly documents the methods, failures, and judgment formed through practice.",
       "facts": [
         {
           "k": "Author",
@@ -356,11 +356,11 @@
         },
         {
           "k": "Identity",
-          "v": "AI founder · Open-source contributor · Digital nomad"
+          "v": "Practitioner · Writer · Open-source contributor"
         },
         {
           "k": "Threads",
-          "v": "AI Agent / Engineering & Open Source / Growth & Thinking / Travel"
+          "v": "AI systems / Engineering methods / Real projects / Growth & philosophy"
         },
         {
           "k": "Footprint",

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -7,7 +7,8 @@
 
 > {{ site.Params.description | plainify }}
 
-Author: Xinwei Xiong (熊鑫伟, cubxxw) — AI Builder, open-source contributor, digital nomad.
+Author: Xinwei Xiong (熊鑫伟, cubxxw), practitioner, writer, and open-source builder.
+Editorial identity: An open archive of lived practice and long-term thought, covering AI workflows, real projects, engineering judgment, systems thinking, personal growth, philosophy, and life.
 Primary domain: {{ site.BaseURL }}
 Available languages: English ({{ site.BaseURL }}), Simplified Chinese ({{ site.BaseURL }}zh/).
 

--- a/layouts/index.llmsfull.txt
+++ b/layouts/index.llmsfull.txt
@@ -7,7 +7,8 @@
 
 > {{ site.Params.description | plainify }}
 
-Author: Xinwei Xiong (熊鑫伟, cubxxw) — AI Builder, open-source contributor, digital nomad.
+Author: Xinwei Xiong (熊鑫伟, cubxxw), practitioner, writer, and open-source builder.
+Editorial identity: An open archive of lived practice and long-term thought, covering AI workflows, real projects, engineering judgment, systems thinking, personal growth, philosophy, and life.
 Primary domain: {{ site.BaseURL }}
 Available languages: English ({{ site.BaseURL }}), Simplified Chinese ({{ site.BaseURL }}zh/).
 

--- a/layouts/partials/home-info.html
+++ b/layouts/partials/home-info.html
@@ -9,15 +9,13 @@
 
     {{- if $isZh -}}
     <div class="home-info-content">
-        <p>你好！我是鑫伟（cubxxw），一名 AI 创业者、开源贡献者和数字游民。</p>
-        <p>这里分享我在 Kubernetes、Go 语言、AI 开源项目等领域的实践笔记，以及个人成长和旅行见闻。</p>
-        <p>从下面的入口开始探索，找到你感兴趣的内容。</p>
+        <p>你好，我是熊鑫伟（cubxxw），一名实践者与写作者。</p>
+        <p>这里是我的公开实践与思想档案，记录 AI 工作流、真实项目、工程方法，以及关于个人成长、哲学与人生的长期思考。</p>
     </div>
     {{- else -}}
     <div class="home-info-content">
-        <p>Hi! I'm Xinwei Xiong (cubxxw), an AI entrepreneur, open source contributor, and digital nomad.</p>
-        <p>I share hands-on notes on Kubernetes, Go, AI open source projects, along with personal growth insights and travel stories.</p>
-        <p>Start exploring from the quick links below and find what resonates with you.</p>
+        <p>Hi, I am Xinwei Xiong (cubxxw), a practitioner and writer.</p>
+        <p>This is my open archive of AI workflows, real projects, engineering methods, and long-term thinking on growth, philosophy, and life.</p>
     </div>
     {{- end -}}
 

--- a/layouts/partials/homepage-daypage.html
+++ b/layouts/partials/homepage-daypage.html
@@ -17,14 +17,6 @@
            Stays empty (transparent) on phones / reduced-motion / no-WebGL. */}}
       <div class="hp-hero-field" id="hp-hero-field" aria-hidden="true"></div>
       <div>
-        <div class="hp-hero-meta-row">
-          <span class="hp-status-pill" id="hp-status-pill">
-            <span class="hp-live-dot"></span>
-            <span id="hp-status-text">{{ if $isZh }}在线 · 漫游中{{ else }}Online · Roaming{{ end }}</span>
-          </span>
-          <span class="hp-entry-label">ENTRY · <span id="hp-entry-date">{{ now.Format "2006/01/02" }}</span></span>
-        </div>
-
         <h1>
           <span class="hp-hero-name-row">
             <span class="hp-hero-name-text">
@@ -53,11 +45,6 @@
           <span class="hp-hero-name-zh">{{ if $isZh }}{{ $d.hero.nameZh }} · {{ $d.hero.nickZh }}{{ else }}熊 · {{ $d.hero.nickZh }}{{ end }}</span>
         </h1>
 
-        <div class="hp-hero-tag">
-          {{- $tags := cond $isZh $d.hero.tagline $d.hero.taglineEn -}}
-          {{- range $i, $tag := $tags }}{{ if $i }}<span class="hp-sep">/</span>{{ end }}<span>{{ $tag }}</span>{{ end }}
-        </div>
-
         <p class="hp-hero-motto">
           {{ if $isZh }}{{ $d.hero.mottoZh }}{{ else }}{{ $d.hero.mottoEn }}{{ end }}
         </p>
@@ -66,18 +53,16 @@
           {{ if $isZh }}{{ $d.hero.bioZh | safeHTML }}{{ else }}{{ $d.hero.bioEn | safeHTML }}{{ end }}
         </p>
 
-        <p class="hp-hero-public">{{ $d.hero.publicLine }}</p>
-
         <a class="hp-hero-cta" href="{{ "/about/" | relLangURL }}">
-          <span>{{ if $isZh }}关于我{{ else }}About Me{{ end }}</span>
+          <span>{{ if $isZh }}了解这个博客{{ else }}About this blog{{ end }}</span>
           <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
         </a>
 
         {{- if site.Params.socialIcons }}
         <div class="hp-hero-socials">
           {{- range site.Params.socialIcons }}
+          {{- $platform := lower .name -}}
           {{- if or (eq .name "wechat") (eq .name "xhs") }}
-          {{- $platform := cond (eq .name "wechat") "wechat" "xhs" -}}
           {{- $asset := cond (eq .name "wechat") "wechat.jpg" "xiaohongshu.jpg" -}}
           {{- $contactID := cond (eq .name "wechat") .wechatID .xhsID -}}
           {{- $contactURL := cond (eq .name "xhs") (trim .url " ") "" -}}
@@ -102,7 +87,7 @@
             {{ partial "svg.html" . }}
           </button>
           {{- else }}
-          <a class="hp-social-icon" href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer" title="{{ .name | title }}">
+          <a class="hp-social-icon hp-social-icon--{{ $platform }}" href="{{ trim .url " " | safeURL }}" target="_blank" rel="noopener noreferrer" title="{{ .name | title }}">
             {{ partial "svg.html" . }}
           </a>
           {{- end }}
@@ -1164,66 +1149,6 @@
       renderYear(thisYear);
     })();
 
-    // 2. RSS fetch only for latest post title → status pill
-    (function() {
-      var rssUrl = isZh ? '/zh/index.xml' : '/index.xml';
-      var CACHE_KEY = 'hp_rss_pill_' + (isZh ? 'zh' : 'en');
-      var CACHE_TTL = 30 * 60 * 1000;
-
-      function applyLatest(item) {
-        var statusEl = document.getElementById('hp-status-text');
-        var dateEl   = document.getElementById('hp-entry-date');
-        if (statusEl && item.title) {
-          var short = item.title.length > 28 ? item.title.slice(0,26) + '…' : item.title;
-          statusEl.textContent = (isZh ? '最新 · ' : 'Latest · ') + short;
-          var pill = document.getElementById('hp-status-pill');
-          if (pill && item.href && item.href !== '#') {
-            pill.style.cursor = 'pointer';
-            pill.onclick = function() { window.open(item.href, '_blank'); };
-            pill.title = item.title;
-          }
-        }
-        if (dateEl && item.date) {
-          var d = item.date;
-          dateEl.textContent = d.getFullYear() + '/' +
-            String(d.getMonth()+1).padStart(2,'0') + '/' +
-            String(d.getDate()).padStart(2,'0');
-        }
-      }
-
-      function parseFirst(xml) {
-        var m = xml.match(/<item[\s\S]*?<\/item>/);
-        if (!m) return null;
-        var item = m[0];
-        var pubM  = item.match(/<pubDate>([^<]+)<\/pubDate>/);
-        var titleM = item.match(/<title>([^<]+)<\/title>/);
-        var linkM  = item.match(/<link>([^<]+)<\/link>/);
-        if (!pubM) return null;
-        return {
-          date:  new Date(pubM[1]),
-          title: titleM ? titleM[1].replace(/&amp;/g,'&').replace(/&lt;/g,'<').replace(/&gt;/g,'>') : '',
-          href:  linkM ? linkM[1].trim() : '#'
-        };
-      }
-
-      try {
-        var cached = sessionStorage.getItem(CACHE_KEY);
-        if (cached) {
-          var obj = JSON.parse(cached);
-          if (Date.now() - obj.ts < CACHE_TTL) { applyLatest(obj.item); return; }
-        }
-      } catch(e) {}
-
-      fetch(rssUrl)
-        .then(function(r) { return r.text(); })
-        .then(function(xml) {
-          var item = parseFirst(xml);
-          if (!item) return;
-          try { sessionStorage.setItem(CACHE_KEY, JSON.stringify({ ts: Date.now(), item: item })); } catch(e) {}
-          applyLatest(item);
-        })
-        .catch(function() {});
-    })();
   })();
 
 

--- a/layouts/partials/seo/structured-data.html
+++ b/layouts/partials/seo/structured-data.html
@@ -183,7 +183,7 @@
     "https://space.bilibili.com/1233089591",
     "https://www.youtube.com/channel/UCd3qbRbMwYlh5uKneo_2m_w"
   ],
-  "jobTitle": "AI Entrepreneur",
+  "jobTitle": "Practitioner, Writer, and Open Source Contributor",
   "worksFor": {
     "@type": "Organization",
     "@id": "{{ site.BaseURL }}#organization",

--- a/layouts/shortcodes/knowledge-galaxy.html
+++ b/layouts/shortcodes/knowledge-galaxy.html
@@ -27,7 +27,7 @@
   {{- /* 降级 / no-JS / no-WebGL 时展示这份静态版本 */ -}}
   <noscript>
     <div class="kg-fallback">
-      <p>{{ if $isZH }}我是 <strong>熊鑫伟（cubxxw）</strong> —— AI 创业者、开源贡献者、数字游民。{{ else }}I'm <strong>Xinwei Xiong (cubxxw)</strong> — AI founder, open-source contributor, digital nomad.{{ end }}</p>
+      <p>{{ if $isZH }}我是 <strong>熊鑫伟（cubxxw）</strong>，一名实践者、写作者与开源贡献者。{{ else }}I am <strong>Xinwei Xiong (cubxxw)</strong>, a practitioner, writer, and open-source contributor.{{ end }}</p>
     </div>
   </noscript>
 </div>
@@ -40,9 +40,9 @@
     "url" (printf "%s/about/" $prefix)
     "color" "#ffffff")
   "nodes" (slice
-    (dict "label" (cond $isZH "AI 创业者" "AI Founder")   "url" (printf "%s/ai-agent/" $prefix)                                                              "color" "#667eea")
+    (dict "label" (cond $isZH "AI 系统" "AI Systems")     "url" (printf "%s/ai-agent/" $prefix)                                                              "color" "#667eea")
     (dict "label" (cond $isZH "开源贡献" "Open Source")    "url" "https://github.com/cubxxw"                                                                       "color" "#764ba2" "external" true)
-    (dict "label" (cond $isZH "数字游民" "Digital Nomad") "url" (printf "%s/travel/" $prefix)                                                                     "color" "#17a2b8")
+    (dict "label" (cond $isZH "实践现场" "Field Notes")   "url" (printf "%s/travel/" $prefix)                                                                     "color" "#17a2b8")
     (dict "label" "Kubernetes"                            "url" (printf "%s/engineering/posts/kubernetes-an-article-to-get-started-quickly/" $prefix)          "color" "#326ce5")
     (dict "label" "Go"                                    "url" (printf "%s/engineering/posts/go-release-tools/" $prefix)                                       "color" "#00add8")
     (dict "label" (cond $isZH "心流状态" "Flow State")    "url" (printf "%s/growth/posts/flow-state/" $prefix)                                                    "color" "#28a745")


### PR DESCRIPTION
## Summary
- replace narrow founder/digital-nomad positioning with a durable practitioner and writer identity
- align homepage, LLM indexes, start-here data, structured data, and knowledge graph copy
- remove dead hero status/RSS code and make mobile social filtering semantic
- stabilize mobile hero typography during webfont loading

## Validation
- `make content-check`
- `make envbuild`
- `git diff --check`
- Playwright at 390px and 1440px; English/Chinese and light/dark reviewed; 0 console errors/warnings
- Lighthouse: performance 70, accessibility 92, SEO 100, CLS 0.005, TBT 0ms