### PR TITLE
Dispatch clean executors from validated blog briefs

### DIFF
--- a/.claude/skills/write-blog-from-brief/SKILL.md
+++ b/.claude/skills/write-blog-from-brief/SKILL.md
@@ -50,6 +50,14 @@ If a better existing article should be updated, report that decision instead of 
 
 Change the selected brief to `claimed` before drafting. Preserve all upstream content.
 
+When invoked by `briefs:dispatch`, the prompt names one specific brief and the dispatcher has already changed it to `claimed`. In that mode:
+
+- process only the named brief;
+- do not run `briefs:next`;
+- do not read or choose another queued brief;
+- do not access the brain repository or resolve `brain://` references;
+- treat the clean process boundary as part of the privacy contract.
+
 ## 2. Build the editorial contract
 
 Extract into working notes:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,11 @@ This document contains critical information about working with this codebase. Fo
 `.claude/skills/write-blog-from-brief/SKILL.md`。该 skill 统一编排公开研究、原生写作、
 独立 agent 审读、AI 味清理、SEO/GEO、内链、封面、评分与确定性验证。
 
+brain 自动下发时使用
+`npm run briefs:dispatch -- --brief _briefs/<file>.md`。该命令启动全新的 ephemeral
+executor，只传任务卡路径，不继承 brain 对话，也不得读取 `brain://` 指向的私有文件。
+定向任务已经由 dispatcher 认领，executor 不再运行 `briefs:next`。
+
 新写或重写文章第一段、开篇 Hook、楔子或首屏时，必须使用
 `.claude/skills/craft-article-opening/SKILL.md`。开篇必须从真实材料建立在场感和张力，
 不得用标题党、虚构经历或泛化的“AI 时代”开场。

--- a/_briefs/2026-07-25-ai-fashion-shein-demand-validation.md
+++ b/_briefs/2026-07-25-ai-fashion-shein-demand-validation.md
@@ -1,13 +1,20 @@
 ---
+schema: blog-brief/v1
+id: 2026-07-25-ai-fashion-shein-demand-validation
 title: AI 能设计一万件衣服，为什么还是做不出下一个 SHEIN？
-target: blog
+status: blocked
+priority: normal
 language: zh
 section: ai-agent
-status: ready
-created_at: 2026-07-25T00:00:00+08:00
+brief_type: research
+dispatched_at: 2026-07-25T00:00:00+08:00
+source_refs:
+  - brain://ventures/cross-border-ecommerce/vault/04-案例库/跨境品牌/SHEIN.md
 ---
 
 # 写作任务卡：AI、服装 C2M 与需求验证
+
+> **blocked**：旧任务卡缺少 `blog-brief/v1` 的已批准素材包与作者第一人称增量确认。补齐后再改回 `ready`，不能让平台侧自行补造。
 
 ## 目标
 

--- a/_briefs/2026-07-26-cross-border-30-day-experiment.md
+++ b/_briefs/2026-07-26-cross-border-30-day-experiment.md
@@ -1,13 +1,20 @@
 ---
+schema: blog-brief/v1
+id: 2026-07-26-cross-border-30-day-experiment
 title: 我为什么没有转行做跨境，而是设计了一场 30 天实验
-target: blog
+status: blocked
+priority: normal
 language: zh
 section: growth
-status: ready
-created_at: 2026-07-26T00:00:00+08:00
+brief_type: thinking
+dispatched_at: 2026-07-26T00:00:00+08:00
+source_refs:
+  - brain://topics/cross-border-30-day-experiment.md
 ---
 
 # 写作任务卡：用 30 天实验进入跨境
+
+> **blocked**：仍需作者确认实验是否启动、预算披露边界与 30 天最小行动。确认前不得创建文章文件。
 
 ## 目标
 

--- a/_briefs/2026-07-31-second-brain-as-survival-strategy.md
+++ b/_briefs/2026-07-31-second-brain-as-survival-strategy.md
@@ -1,10 +1,16 @@
 ---
+schema: blog-brief/v1
+id: 2026-07-31-second-brain-as-survival-strategy
 title: 第二大脑保存的是一个人的决策函数
-status: ready
-platform: blog
+status: published
+priority: normal
 language: zh
 section: growth
+brief_type: thinking
 dispatched_at: 2026-07-31T01:50:37+08:00
+source_refs:
+  - brain://topics/second-brain-as-survival-strategy.md
+  - brain://figures/lu-yuqi/index.md
 ---
 
 # 写作任务：第二大脑保存的是一个人的决策函数
@@ -202,3 +208,12 @@ brain、DayPage 的 file-system vault、`hot.md`、cct 会话捕获、provider �
 ---
 
 平台侧必须依据本仓库 `CLAUDE.md` 与内容规范原生写作。不要把这张 brief 或任何 brain 原文直接当成成品发布；不要把同一稿复制到其他平台。
+
+## 执行回执
+
+- article: `content/zh/growth/posts/2026-07-31-second-brain-as-survival-strategy.md`
+- public_url: `https://cubxxw.com/zh/growth/posts/2026-07-31-second-brain-as-survival-strategy/`
+- score: legacy workflow，未按当前 100 分 rubric 留存
+- checks: 文章已存在并发布；本次迁移只修正重复队列状态
+- published_at: 2026-07-31T11:30:50+08:00
+- retro_notes: 旧 brief 曾保持 `ready`，导致已发布文章重复进入队列；已迁移为 `published`。

--- a/_briefs/README.md
+++ b/_briefs/README.md
@@ -25,6 +25,7 @@
 
 - 一篇候选文章一个文件：`YYYY-MM-DD-<slug>.md`。
 - 新 brief 使用 [`_TEMPLATE.md`](./_TEMPLATE.md)。
+- 进入队列的任务必须使用 `schema: blog-brief/v1`；legacy 文件和缺少必填区块的任务不会被执行。
 - `content/` 只存放可发布文章；未完成内容留在工作分支或 brief，不创建隐藏占位页。
 - `source_refs` 使用 `brain://` 标识，不写机器绝对路径，也不复制 private 内容。
 - 上游引用只是溯源线索。真正允许进入公开文章的内容必须同时出现在 brief 的“已批准素材包”中。
@@ -61,13 +62,31 @@ ready / blocked → cancelled
 npm run briefs:list
 npm run briefs:next
 npm run briefs:check
+npm run briefs:dispatch -- --brief _briefs/YYYY-MM-DD-slug.md
 ```
 
 - `briefs:list`：查看所有可执行和进行中的 brief。
 - `briefs:next`：按优先级和下发时间选择下一篇，但不自动修改状态。
-- `briefs:check`：校验采用 `blog-brief/v1` 的新任务卡。
+- `briefs:check`：严格校验 `blog-brief/v1` 的字段、必填区块、隐私边界、本机路径与同 slug 重复文章。
+- `briefs:dispatch`：校验并认领指定 brief，然后用 `codex exec --ephemeral` 启动一个不继承 brain 对话的干净执行上下文。
+
+预演 dispatch，不认领也不启动 executor：
+
+```bash
+npm run briefs:dispatch -- --brief _briefs/YYYY-MM-DD-slug.md --dry-run
+```
 
 定期自动化每次最多认领一篇。找不到 `ready` 时正常退出，不为了维持产量自行创造选题。
+
+## 干净 executor 契约
+
+- executor 的工作目录只能是当前 blog 仓库；不得添加 brain 为可写目录。
+- executor 只接收目标 brief 的相对路径，不继承上游对话、研究草稿或 brain 全量上下文。
+- `brain://` 保持为回溯标识，executor 不读取其目标。
+- dispatch 前 blog 工作树除目标 brief 外必须干净，避免覆盖作者或其他任务的改动。
+- dispatch 先原子认领目标 brief；同一时间存在其他 active brief 时拒绝启动。
+- executor 若在认领后、正式开工前异常退出，调度器把 `claimed` 释放回 `ready`；进入 `drafting` 后的失败保留现场，等待人工恢复。
+- executor 不 commit、不 push、不部署，最高只推进到 `ready-to-publish`。
 
 ## 消费流程
 

--- a/docs/blog-editorial-workflow.md
+++ b/docs/blog-editorial-workflow.md
@@ -6,7 +6,8 @@
 
 ```text
 brain 下发 brief
-  → 队列扫描与认领
+  → 严格校验
+  → 干净 executor 定向认领
   → 站内查重
   → 材料与缺口梳理
   → 外部研究 + 搜索意图研究
@@ -22,6 +23,8 @@ brain 下发 brief
 
 每次只处理一个 brief。高产不是目标；brief 没有达到写作条件时，正确结果是 `blocked`。
 
+上游可以通过 `npm run briefs:dispatch -- --brief <path>` 自动启动执行，但自动化只传递任务卡路径。新 executor 不继承 brain 会话，也不得读取 `brain://` 对应的私有文件。
+
 ## 1. 扫描与认领
 
 运行：
@@ -29,6 +32,8 @@ brain 下发 brief
 ```bash
 npm run briefs:next
 ```
+
+若任务由 brain 定向 dispatch，brief 已经是 `claimed`，直接处理指定文件，不再运行 `briefs:next`，也不得切换到队列里的其他任务。
 
 选择顺序：
 
@@ -46,6 +51,8 @@ npm run briefs:next
 - 允许公开的素材包；
 - 隐私边界；
 - 关键经历是否真实发生的确认。
+
+`briefs:check` 会先拦截结构性问题、legacy actionable brief、本机绝对路径和同 slug 已存在文章；语义真实性仍由 executor 审核，不能交给格式脚本代替。
 
 ## 2. 先整理研究问题，不直接写正文
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "briefs:list": "node scripts/brief-queue.mjs",
     "briefs:next": "node scripts/brief-queue.mjs --next",
     "briefs:check": "node scripts/brief-queue.mjs --check",
+    "briefs:dispatch": "node scripts/dispatch-blog-executor.mjs",
+    "briefs:test": "node --test scripts/brief-queue.test.mjs scripts/dispatch-blog-executor.test.mjs",
     "tags:check": "node scripts/normalize-tags.mjs --check",
     "tags:fix": "node scripts/normalize-tags.mjs --write",
     "flavor:check": "node scripts/check-ai-flavor.mjs --changed --check",

--- a/scripts/brief-queue.mjs
+++ b/scripts/brief-queue.mjs
@@ -4,14 +4,25 @@ import {
   existsSync,
   readFileSync,
   readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
 } from 'node:fs';
-import { basename, join, relative, resolve } from 'node:path';
+import { basename, dirname, join, relative, resolve, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
-const BRIEFS_DIR = join(ROOT, '_briefs');
-const ACTIONABLE = new Set(['ready', 'revision']);
+const BRIEFS_DIR = resolve(process.env.BLOG_BRIEFS_DIR || join(ROOT, '_briefs'));
+const CONTENT_DIR = resolve(process.env.BLOG_CONTENT_DIR || join(ROOT, 'content'));
+const ACTIONABLE = new Set(['ready']);
 const ACTIVE = new Set(['claimed', 'drafting', 'review']);
+const EXECUTABLE = new Set([
+  'ready',
+  'claimed',
+  'drafting',
+  'review',
+  'ready-to-publish',
+]);
 const VALID_V1_STATUSES = new Set([
   'ready',
   'claimed',
@@ -22,6 +33,7 @@ const VALID_V1_STATUSES = new Set([
   'blocked',
   'cancelled',
 ]);
+const VALID_BRIEF_TYPES = new Set(['thinking', 'research', 'maintenance']);
 const PRIORITY_RANK = new Map([
   ['high', 0],
   ['normal', 1],
@@ -34,7 +46,50 @@ function frontMatter(text) {
 }
 
 function scalar(fm, key) {
-  const match = fm.match(new RegExp(`^${key}:\\s*['"]?([^\\n'"]+)['"]?\\s*$`, 'm'));
+  const match = fm.match(
+    new RegExp(`^${key}:\\s*['"]?([^\\n'"]+)['"]?\\s*$`, 'm'),
+  );
+  return match?.[1]?.trim() ?? '';
+}
+
+function listValues(fm, key) {
+  const lines = fm.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === `${key}:`);
+  if (start < 0) return [];
+
+  const values = [];
+  for (const line of lines.slice(start + 1)) {
+    const item = line.match(/^\s+-\s+(.+?)\s*$/);
+    if (item) {
+      values.push(item[1].replace(/^['"]|['"]$/g, ''));
+      continue;
+    }
+    if (/^\S/.test(line)) break;
+  }
+  return values;
+}
+
+function sectionBody(text, headings) {
+  for (const heading of headings) {
+    const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = text.match(
+      new RegExp(
+        `^##\\s+${escaped}\\s*$\\r?\\n([\\s\\S]*?)(?=^##\\s+|(?![\\s\\S]))`,
+        'm',
+      ),
+    );
+    const body = match?.[1]
+      ?.replace(/<!--[\s\S]*?-->/g, '')
+      .trim();
+    if (body) return body;
+  }
+  return '';
+}
+
+function receiptValue(text, key) {
+  const match = text.match(
+    new RegExp(`^-\\s+${key}:\\s*[\`'"]?([^\\n\`'"]*)[\`'"]?\\s*$`, 'm'),
+  );
   return match?.[1]?.trim() ?? '';
 }
 
@@ -47,6 +102,9 @@ function readBrief(file) {
   return {
     file,
     path: relative(ROOT, file),
+    filename,
+    text,
+    fm,
     schema: scalar(fm, 'schema'),
     id: scalar(fm, 'id') || filename.replace(/\.md$/, ''),
     title: scalar(fm, 'title') || filename,
@@ -54,11 +112,13 @@ function readBrief(file) {
     priority: scalar(fm, 'priority') || 'normal',
     language: scalar(fm, 'language'),
     section: scalar(fm, 'section'),
+    briefType: scalar(fm, 'brief_type'),
+    sourceRefs: listValues(fm, 'source_refs'),
     dispatchedAt:
       scalar(fm, 'dispatched_at') ||
       scalar(fm, 'created_at') ||
       legacyDate,
-    fm,
+    article: receiptValue(text, 'article'),
   };
 }
 
@@ -81,12 +141,60 @@ function compareBriefs(a, b) {
   return a.dispatchedAt.localeCompare(b.dispatchedAt) || a.id.localeCompare(b.id);
 }
 
-function validateV1(brief) {
-  if (brief.schema !== 'blog-brief/v1') return [];
+function markdownFiles(directory) {
+  if (!existsSync(directory)) return [];
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) files.push(...markdownFiles(path));
+    else if (entry.isFile() && entry.name.endsWith('.md')) files.push(path);
+  }
+  return files;
+}
 
+function duplicateArticles(brief) {
+  if (!EXECUTABLE.has(brief.status) || brief.briefType === 'maintenance') {
+    return [];
+  }
+
+  const duplicates = [];
+  if (brief.article) {
+    const article = resolve(ROOT, brief.article);
+    if (article.startsWith(`${ROOT}${sep}`) && existsSync(article)) {
+      duplicates.push(relative(ROOT, article));
+    }
+  }
+
+  const slug = brief.id.replace(/^\d{4}-\d{2}-\d{2}-/, '');
+  const expected = `${slug}.md`;
+  for (const file of markdownFiles(CONTENT_DIR)) {
+    if (basename(file) === expected) duplicates.push(relative(ROOT, file));
+  }
+  return [...new Set(duplicates)];
+}
+
+function validateV1(brief) {
   const errors = [];
-  for (const field of ['id', 'title', 'status', 'language', 'section', 'dispatchedAt']) {
-    if (!brief[field]) errors.push(`missing ${field}`);
+  if (brief.schema !== 'blog-brief/v1') {
+    errors.push('missing or unsupported schema; expected blog-brief/v1');
+    return errors;
+  }
+
+  for (const [field, value] of [
+    ['id', brief.id],
+    ['title', brief.title],
+    ['status', brief.status],
+    ['priority', brief.priority],
+    ['language', brief.language],
+    ['section', brief.section],
+    ['brief_type', brief.briefType],
+    ['dispatched_at', brief.dispatchedAt],
+  ]) {
+    if (!value) errors.push(`missing ${field}`);
+  }
+
+  if (brief.id !== brief.filename.replace(/\.md$/, '')) {
+    errors.push(`id "${brief.id}" must match filename`);
   }
   if (!VALID_V1_STATUSES.has(brief.status)) {
     errors.push(`invalid status "${brief.status}"`);
@@ -94,7 +202,86 @@ function validateV1(brief) {
   if (!PRIORITY_RANK.has(brief.priority)) {
     errors.push(`invalid priority "${brief.priority}"`);
   }
+  if (!VALID_BRIEF_TYPES.has(brief.briefType)) {
+    errors.push(`invalid brief_type "${brief.briefType}"`);
+  }
+  if (brief.dispatchedAt && Number.isNaN(Date.parse(brief.dispatchedAt))) {
+    errors.push(`invalid dispatched_at "${brief.dispatchedAt}"`);
+  }
+
+  for (const ref of brief.sourceRefs) {
+    if (!ref.startsWith('brain://')) {
+      errors.push(`source_ref must use brain://: "${ref}"`);
+    }
+  }
+  if (/file:\/\/|\/Users\/|\/home\/|[A-Za-z]:\\/.test(brief.fm)) {
+    errors.push('front matter contains a machine-local path');
+  }
+
+  if (EXECUTABLE.has(brief.status)) {
+    const requiredSections = [
+      ['唯一命题', ['唯一命题']],
+      ['为什么值得由我写', ['为什么值得由我写']],
+      ['目标读者与阅读场景', ['目标读者与阅读场景']],
+      ['已批准素材包', ['已批准素材包']],
+      ['证据与隐私边界', ['证据与隐私边界']],
+      ['验收标准', ['验收标准']],
+    ];
+    for (const [label, headings] of requiredSections) {
+      if (!sectionBody(brief.text, headings)) {
+        errors.push(`missing or empty section "## ${label}"`);
+      }
+    }
+
+    const privacy = sectionBody(brief.text, ['证据与隐私边界']);
+    for (const label of ['可以公开', '必须匿名', '禁止使用', '发布前仍需作者确认']) {
+      if (!privacy.includes(label)) {
+        errors.push(`privacy section missing "${label}" boundary`);
+      }
+    }
+
+    for (const duplicate of duplicateArticles(brief)) {
+      errors.push(`possible duplicate article already exists: ${duplicate}`);
+    }
+  }
+
   return errors;
+}
+
+function resolveBriefPath(input) {
+  const file = resolve(ROOT, input);
+  if (!file.startsWith(`${BRIEFS_DIR}${sep}`)) {
+    throw new Error(`brief must be inside ${relative(ROOT, BRIEFS_DIR)}/`);
+  }
+  if (!existsSync(file) || !statSync(file).isFile()) {
+    throw new Error(`brief not found: ${input}`);
+  }
+  return file;
+}
+
+function replaceStatus(file, from, to) {
+  const text = readFileSync(file, 'utf8');
+  const current = scalar(frontMatter(text), 'status');
+  if (current !== from) {
+    throw new Error(`expected status "${from}", found "${current}"`);
+  }
+  const next = text.replace(
+    /^status:\s*['"]?[^'"\n]+['"]?\s*$/m,
+    `status: ${to}`,
+  );
+  if (next === text) throw new Error('status field was not updated');
+  const temporary = join(
+    dirname(file),
+    `.${basename(file)}.${process.pid}.tmp`,
+  );
+  writeFileSync(temporary, next);
+  renameSync(temporary, file);
+}
+
+function printErrors(brief, errors) {
+  for (const error of errors) {
+    console.error(`ERROR ${brief.path}: ${error}`);
+  }
 }
 
 function printBrief(brief) {
@@ -105,47 +292,111 @@ function printBrief(brief) {
   console.log(`  ${brief.title}`);
 }
 
-const args = new Set(process.argv.slice(2));
-const briefs = collectBriefs().sort(compareBriefs);
-const actionable = briefs.filter((brief) => ACTIONABLE.has(brief.status));
-const active = briefs.filter((brief) => ACTIVE.has(brief.status));
-
-if (args.has('--json')) {
-  console.log(JSON.stringify({ actionable, active, all: briefs }, null, 2));
-  process.exit(0);
-}
-
-if (args.has('--check')) {
-  let errorCount = 0;
-  let legacyCount = 0;
-  for (const brief of briefs) {
-    if (!brief.schema) {
-      legacyCount += 1;
-      console.log(`WARN ${brief.path}: legacy brief without schema`);
-      continue;
-    }
-    for (const error of validateV1(brief)) {
-      errorCount += 1;
-      console.error(`ERROR ${brief.path}: ${error}`);
-    }
+function argumentValue(args, flag) {
+  const index = args.indexOf(flag);
+  if (index < 0) return '';
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
   }
-  console.log(
-    `Checked ${briefs.length} brief(s): ${errorCount} error(s), ${legacyCount} legacy.`,
-  );
-  process.exit(errorCount > 0 ? 1 : 0);
+  return value;
 }
 
-if (args.has('--next')) {
-  const next = actionable[0];
-  if (!next) {
-    console.log('No actionable brief.');
+function main() {
+  const args = process.argv.slice(2);
+  const briefs = collectBriefs().sort(compareBriefs);
+  const checkFile = argumentValue(args, '--file');
+  const claimFile = argumentValue(args, '--claim');
+  const releaseFile = argumentValue(args, '--release');
+
+  if (args.includes('--check')) {
+    const selected = checkFile
+      ? [readBrief(resolveBriefPath(checkFile))]
+      : briefs;
+    let errorCount = 0;
+    let legacyCount = 0;
+    for (const brief of selected) {
+      const errors = validateV1(brief);
+      if (brief.schema !== 'blog-brief/v1') legacyCount += 1;
+      errorCount += errors.length;
+      printErrors(brief, errors);
+    }
+    console.log(
+      `Checked ${selected.length} brief(s): ${errorCount} error(s), ${legacyCount} legacy.`,
+    );
+    process.exit(errorCount > 0 ? 1 : 0);
+  }
+
+  if (claimFile) {
+    const brief = readBrief(resolveBriefPath(claimFile));
+    const errors = validateV1(brief);
+    if (brief.status !== 'ready') {
+      errors.push(`cannot claim status "${brief.status}"`);
+    }
+    const otherActive = briefs.filter(
+      (candidate) =>
+        ACTIVE.has(candidate.status) && candidate.file !== brief.file,
+    );
+    for (const active of otherActive) {
+      errors.push(`another brief is active: ${active.path} (${active.status})`);
+    }
+    if (errors.length > 0) {
+      printErrors(brief, errors);
+      process.exit(1);
+    }
+    replaceStatus(brief.file, 'ready', 'claimed');
+    console.log(`Claimed ${brief.path}`);
     process.exit(0);
   }
-  printBrief(next);
-  process.exit(0);
+
+  if (releaseFile) {
+    const brief = readBrief(resolveBriefPath(releaseFile));
+    replaceStatus(brief.file, 'claimed', 'ready');
+    console.log(`Released ${brief.path}`);
+    process.exit(0);
+  }
+
+  const actionableProblems = briefs
+    .filter((brief) => ACTIONABLE.has(brief.status))
+    .map((brief) => [brief, validateV1(brief)])
+    .filter(([, errors]) => errors.length > 0);
+  if (actionableProblems.length > 0) {
+    for (const [brief, errors] of actionableProblems) {
+      printErrors(brief, errors);
+    }
+    process.exit(1);
+  }
+
+  const actionable = briefs.filter(
+    (brief) =>
+      brief.schema === 'blog-brief/v1' && ACTIONABLE.has(brief.status),
+  );
+  const active = briefs.filter((brief) => ACTIVE.has(brief.status));
+
+  if (args.includes('--json')) {
+    console.log(JSON.stringify({ actionable, active, all: briefs }, null, 2));
+    process.exit(0);
+  }
+
+  if (args.includes('--next')) {
+    const next = actionable[0];
+    if (!next) {
+      console.log('No actionable brief.');
+      process.exit(0);
+    }
+    printBrief(next);
+    process.exit(0);
+  }
+
+  console.log(
+    `Brief queue: ${actionable.length} actionable, ${active.length} active, ${briefs.length} total.\n`,
+  );
+  for (const brief of [...actionable, ...active]) printBrief(brief);
 }
 
-console.log(
-  `Brief queue: ${actionable.length} actionable, ${active.length} active, ${briefs.length} total.\n`,
-);
-for (const brief of [...actionable, ...active]) printBrief(brief);
+try {
+  main();
+} catch (error) {
+  console.error(`ERROR ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/brief-queue.test.mjs
+++ b/scripts/brief-queue.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT = fileURLToPath(new URL('./brief-queue.mjs', import.meta.url));
+
+function fixture(status = 'ready') {
+  return `---
+schema: blog-brief/v1
+id: 2026-08-01-test-brief
+title: 测试任务
+status: ${status}
+priority: normal
+language: zh
+section: growth
+brief_type: thinking
+dispatched_at: 2026-08-01T12:00:00+08:00
+source_refs:
+  - brain://topics/test-brief.md
+---
+
+## 唯一命题
+
+一个明确判断。
+
+## 为什么值得由我写
+
+一条作者一手经验。
+
+## 目标读者与阅读场景
+
+正在做决策的读者。
+
+## 已批准素材包
+
+### 事实与项目证据
+
+- 一条已批准事实。
+
+## 证据与隐私边界
+
+- 可以公开：上述事实。
+- 必须匿名：无。
+- 禁止使用：私密原文。
+- 发布前仍需作者确认：无。
+
+## 验收标准
+
+- [ ] 只推进唯一命题。
+`;
+}
+
+function setup() {
+  const root = mkdtempSync(join(tmpdir(), 'brief-queue-'));
+  const briefs = join(root, '_briefs');
+  const content = join(root, 'content');
+  mkdirSync(briefs);
+  mkdirSync(content);
+  return {
+    briefs,
+    content,
+    env: {
+      ...process.env,
+      BLOG_BRIEFS_DIR: briefs,
+      BLOG_CONTENT_DIR: content,
+    },
+  };
+}
+
+test('strict validation accepts a complete v1 brief', () => {
+  const { briefs, env } = setup();
+  writeFileSync(join(briefs, '2026-08-01-test-brief.md'), fixture());
+  const output = execFileSync(
+    process.execPath,
+    [SCRIPT, '--check'],
+    { encoding: 'utf8', env },
+  );
+  assert.match(output, /0 error/);
+});
+
+test('legacy ready briefs fail instead of entering the queue', () => {
+  const { briefs, env } = setup();
+  writeFileSync(
+    join(briefs, '2026-08-01-test-brief.md'),
+    '---\ntitle: Legacy\nstatus: ready\n---\n',
+  );
+  const result = spawnSync(process.execPath, [SCRIPT, '--check'], {
+    encoding: 'utf8',
+    env,
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /expected blog-brief\/v1/);
+});
+
+test('claim and release perform guarded state transitions', () => {
+  const { briefs, env } = setup();
+  const file = join(briefs, '2026-08-01-test-brief.md');
+  writeFileSync(file, fixture());
+  execFileSync(
+    process.execPath,
+    [SCRIPT, '--claim', file],
+    { encoding: 'utf8', env },
+  );
+  let text = execFileSync('sed', ['-n', '1,12p', file], { encoding: 'utf8' });
+  assert.match(text, /status: claimed/);
+
+  execFileSync(
+    process.execPath,
+    [SCRIPT, '--release', file],
+    { encoding: 'utf8', env },
+  );
+  text = execFileSync('sed', ['-n', '1,12p', file], { encoding: 'utf8' });
+  assert.match(text, /status: ready/);
+});
+
+test('ready brief is rejected when an article with the same slug exists', () => {
+  const { briefs, content, env } = setup();
+  writeFileSync(join(briefs, '2026-08-01-test-brief.md'), fixture());
+  mkdirSync(join(content, 'zh', 'growth', 'posts'), { recursive: true });
+  writeFileSync(join(content, 'zh', 'growth', 'posts', 'test-brief.md'), '---\n---\n');
+
+  const result = spawnSync(process.execPath, [SCRIPT, '--check'], {
+    encoding: 'utf8',
+    env,
+  });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /possible duplicate article/);
+});

--- a/scripts/dispatch-blog-executor.mjs
+++ b/scripts/dispatch-blog-executor.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+} from 'node:fs';
+import { basename, join, relative, resolve, sep } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = resolve(
+  process.env.BLOG_REPO_ROOT ||
+    fileURLToPath(new URL('..', import.meta.url)),
+);
+const BRIEFS_DIR = join(ROOT, '_briefs');
+const OUTPUT_DIR = join(ROOT, '_output', 'brief-executors');
+
+function argumentValue(args, flag) {
+  const index = args.indexOf(flag);
+  if (index < 0) return '';
+  const value = args[index + 1];
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return value;
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: options.stdio || 'pipe',
+  });
+  if (result.error) throw result.error;
+  return result;
+}
+
+function resolveBrief(input) {
+  const file = resolve(ROOT, input);
+  if (!file.startsWith(`${BRIEFS_DIR}${sep}`)) {
+    throw new Error('brief must be inside _briefs/');
+  }
+  if (!existsSync(file)) throw new Error(`brief not found: ${input}`);
+  return file;
+}
+
+function statusOf(file) {
+  const match = readFileSync(file, 'utf8').match(
+    /^status:\s*['"]?([^'"\n]+)['"]?\s*$/m,
+  );
+  return match?.[1]?.trim() ?? '';
+}
+
+function assertWorktreeScope(brief) {
+  const status = run('git', ['status', '--porcelain', '--untracked-files=all']);
+  if (status.status !== 0) {
+    throw new Error(status.stderr || 'unable to inspect git worktree');
+  }
+  const allowed = relative(ROOT, brief);
+  const unrelated = status.stdout
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .map((line) => line.slice(3).replace(/^"|"$/g, ''))
+    .filter((path) => path !== allowed);
+  if (unrelated.length > 0) {
+    throw new Error(
+      `blog worktree has unrelated changes: ${unrelated.join(', ')}`,
+    );
+  }
+}
+
+function assertRemoteCurrent() {
+  const upstream = run('git', [
+    'rev-parse',
+    '--abbrev-ref',
+    '--symbolic-full-name',
+    '@{upstream}',
+  ]);
+  if (upstream.status !== 0) return;
+
+  const remote = upstream.stdout.trim().split('/')[0];
+  const fetch = run('git', ['fetch', '--quiet', remote]);
+  if (fetch.status !== 0) {
+    throw new Error(fetch.stderr || `unable to fetch ${remote}`);
+  }
+
+  const counts = run('git', [
+    'rev-list',
+    '--left-right',
+    '--count',
+    `HEAD...${upstream.stdout.trim()}`,
+  ]);
+  if (counts.status !== 0) {
+    throw new Error(counts.stderr || 'unable to compare upstream branch');
+  }
+  const [, behindText] = counts.stdout.trim().split(/\s+/);
+  const behind = Number(behindText || 0);
+  if (behind > 0) {
+    throw new Error(
+      `current branch is ${behind} commit(s) behind ${upstream.stdout.trim()}; update before dispatch`,
+    );
+  }
+}
+
+function executorPrompt(brief) {
+  const path = relative(ROOT, brief);
+  return `你是一个全新的 blog executor，只在当前 blog 仓库内工作。
+
+目标：把指定任务卡 ${path} 执行到 ready-to-publish，或在材料不足时明确 blocked。
+
+边界：
+- 不得访问 brain 仓库、brain:// 引用目标或任何上游私有文件；只使用任务卡“已批准素材包”。
+- 不继承或猜测上游对话。任务卡是唯一编辑契约。
+- 先读取 CLAUDE.md、_briefs/README.md、docs/blog-editorial-workflow.md、.claude/skills/write-blog-from-brief/SKILL.md，并严格执行。
+- 这是定向 dispatch：目标 brief 已由调度器认领。不要运行 briefs:next，不要切换到其他 brief。
+- 若当前仍在 main，先创建并切换到 codex/brief-${basename(brief, '.md')} 分支，再开始内容修改。
+- 保留无关改动；不 commit、不 push、不合并、不部署、不标记 published。
+- 公开研究、博客原生写作、独立审读、SEO/GEO、封面与验证都归当前仓库负责。
+- 若被作者确认、证据或隐私边界阻塞，把目标 brief 标记为 blocked，并写清解除条件。
+- 所有质量门通过后，把目标 brief 标记为 ready-to-publish，填写执行回执并停止。`;
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const briefInput = argumentValue(args, '--brief');
+  if (!briefInput) throw new Error('usage: --brief _briefs/<file>.md [--dry-run]');
+
+  const brief = resolveBrief(briefInput);
+  const relativeBrief = relative(ROOT, brief);
+  const dryRun = args.includes('--dry-run');
+  const codexBin = argumentValue(args, '--codex-bin') || 'codex';
+
+  const validation = run('node', [
+    'scripts/brief-queue.mjs',
+    '--check',
+    '--file',
+    relativeBrief,
+  ]);
+  if (validation.status !== 0) {
+    process.stderr.write(validation.stderr);
+    process.stdout.write(validation.stdout);
+    process.exit(validation.status || 1);
+  }
+
+  const prompt = executorPrompt(brief);
+
+  if (dryRun) {
+    console.log(validation.stdout.trim());
+    console.log(`Dry run: clean executor would process ${relativeBrief}`);
+    console.log('\n--- executor prompt ---\n');
+    console.log(prompt);
+    process.exit(0);
+  }
+
+  assertWorktreeScope(brief);
+  assertRemoteCurrent();
+
+  const claim = run('node', [
+    'scripts/brief-queue.mjs',
+    '--claim',
+    relativeBrief,
+  ]);
+  if (claim.status !== 0) {
+    process.stderr.write(claim.stderr);
+    process.stdout.write(claim.stdout);
+    process.exit(claim.status || 1);
+  }
+  console.log(claim.stdout.trim());
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const id = basename(brief, '.md');
+  const lastMessage = join(OUTPUT_DIR, `${id}.md`);
+  const result = run(
+    codexBin,
+    [
+      'exec',
+      '--ephemeral',
+      '--cd',
+      ROOT,
+      '--sandbox',
+      'workspace-write',
+      '--output-last-message',
+      lastMessage,
+      prompt,
+    ],
+    { stdio: 'inherit' },
+  );
+
+  if (result.status !== 0) {
+    if (statusOf(brief) === 'claimed') {
+      const release = run('node', [
+        'scripts/brief-queue.mjs',
+        '--release',
+        relativeBrief,
+      ]);
+      if (release.status === 0) {
+        console.error('Executor failed before work began; claim released.');
+      }
+    }
+    process.exit(result.status || 1);
+  }
+
+  console.log(`Executor finished. Last message: ${relative(ROOT, lastMessage)}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`ERROR ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/dispatch-blog-executor.test.mjs
+++ b/scripts/dispatch-blog-executor.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const DISPATCH = fileURLToPath(
+  new URL('./dispatch-blog-executor.mjs', import.meta.url),
+);
+const QUEUE = fileURLToPath(new URL('./brief-queue.mjs', import.meta.url));
+
+function brief() {
+  return `---
+schema: blog-brief/v1
+id: 2026-08-01-test-dispatch
+title: 测试自动下发
+status: ready
+priority: normal
+language: zh
+section: growth
+brief_type: thinking
+dispatched_at: 2026-08-01T12:00:00+08:00
+source_refs:
+  - brain://topics/test-dispatch.md
+---
+
+## 唯一命题
+
+一个明确判断。
+
+## 为什么值得由我写
+
+一条作者经验。
+
+## 目标读者与阅读场景
+
+正在做决策的读者。
+
+## 已批准素材包
+
+- 一条已批准事实。
+
+## 证据与隐私边界
+
+- 可以公开：上述事实。
+- 必须匿名：无。
+- 禁止使用：私密原文。
+- 发布前仍需作者确认：无。
+
+## 验收标准
+
+- [ ] 只推进唯一命题。
+`;
+}
+
+function setup(fakeExit = 0) {
+  const root = mkdtempSync(join(tmpdir(), 'brief-dispatch-'));
+  mkdirSync(join(root, 'scripts'));
+  mkdirSync(join(root, '_briefs'));
+  mkdirSync(join(root, 'content'));
+  copyFileSync(QUEUE, join(root, 'scripts', 'brief-queue.mjs'));
+  copyFileSync(DISPATCH, join(root, 'scripts', 'dispatch-blog-executor.mjs'));
+
+  const fakeCodex = join(root, 'fake-codex.mjs');
+  writeFileSync(
+    fakeCodex,
+    `#!/usr/bin/env node
+import { writeFileSync } from 'node:fs';
+writeFileSync(process.env.FAKE_CODEX_LOG, JSON.stringify(process.argv.slice(2)));
+process.exit(${fakeExit});
+`,
+  );
+  chmodSync(fakeCodex, 0o755);
+
+  execFileSync('git', ['init', '-q'], { cwd: root });
+  execFileSync('git', ['config', 'user.email', 'test@example.com'], { cwd: root });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: root });
+  execFileSync('git', ['add', 'scripts', 'fake-codex.mjs'], { cwd: root });
+  execFileSync('git', ['commit', '-qm', 'test fixture'], { cwd: root });
+
+  const briefPath = join(root, '_briefs', '2026-08-01-test-dispatch.md');
+  writeFileSync(briefPath, brief());
+
+  return {
+    root,
+    briefPath,
+    fakeCodex,
+    log: join(tmpdir(), `fake-codex-${process.pid}-${Math.random()}.json`),
+  };
+}
+
+test('dispatch validates, claims, and starts an ephemeral executor', () => {
+  const fixture = setup();
+  const env = {
+    ...process.env,
+    BLOG_REPO_ROOT: fixture.root,
+    FAKE_CODEX_LOG: fixture.log,
+  };
+  execFileSync(
+    process.execPath,
+    [
+      DISPATCH,
+      '--brief',
+      '_briefs/2026-08-01-test-dispatch.md',
+      '--codex-bin',
+      fixture.fakeCodex,
+    ],
+    { env, encoding: 'utf8' },
+  );
+
+  assert.match(readFileSync(fixture.briefPath, 'utf8'), /status: claimed/);
+  const args = JSON.parse(readFileSync(fixture.log, 'utf8'));
+  assert.deepEqual(args.slice(0, 2), ['exec', '--ephemeral']);
+  assert.ok(args.includes('--sandbox'));
+});
+
+test('dispatch releases an untouched claim when executor startup fails', () => {
+  const fixture = setup(2);
+  const env = {
+    ...process.env,
+    BLOG_REPO_ROOT: fixture.root,
+    FAKE_CODEX_LOG: fixture.log,
+  };
+  const result = spawnSync(
+    process.execPath,
+    [
+      DISPATCH,
+      '--brief',
+      '_briefs/2026-08-01-test-dispatch.md',
+      '--codex-bin',
+      fixture.fakeCodex,
+    ],
+    { env, encoding: 'utf8' },
+  );
+
+  assert.equal(result.status, 2);
+  assert.match(readFileSync(fixture.briefPath, 'utf8'), /status: ready/);
+  assert.match(result.stderr, /claim released/);
+});


### PR DESCRIPTION
## Summary

- add strict blog-brief/v1 validation, duplicate detection, and guarded state transitions
- add ephemeral Codex dispatch with clean-context and privacy boundaries
- add success and failure-path tests
- migrate legacy briefs out of the actionable queue

## Validation

- 6 brief and dispatch tests passed
- all 5 briefs validate with 0 errors and 0 legacy files
- Hugo production build passed
- TypeScript check passed
- real ephemeral Codex startup probe passed

## Impact

Brain can hand off a compiled brief and automatically start a blog-native executor without exposing upstream private context. Execution still stops at ready-to-publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added targeted brief dispatch with dry-run support and isolated execution.
  * Added strict validation for brief format, required fields, statuses, source references, and duplicate articles.
  * Added claim and release workflows with recovery when execution fails.
* **Documentation**
  * Updated editorial workflow guidance, queue requirements, and execution safeguards.
* **Bug Fixes**
  * Prevented invalid, incomplete, legacy, or duplicate briefs from entering processing.
  * Improved handling of blocked briefs requiring author confirmation or source materials.
* **Tests**
  * Added coverage for validation, dispatch, claiming, releasing, and failure recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->